### PR TITLE
fix: sensor crash when mount is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The config parameters that need to be defined are:
 - `tumor_evolution.output_directory`: The directory where the evolution reports will be saved.
 - `tumor_evolution.watch_file`: The path to the file that will be watched for new requests to generate reports.
 - `tumor_evolution.version`: The version of the tumor-evolution script to be used.
+- `notification_email`: An array of email addresses where notifications will be sent
 
 ## Actions
 
@@ -26,6 +27,7 @@ gmc_norr_analysis.write_file                      | Write a text string to a fil
 ref                                               | description
 --------------------------------------------------|---------------------------------
 gmc_norr_analysis.generate_tumor_evolution_report | Generate tumor evolution report
+gmc_norr_analysis.send_notification_email         | Send a notification email
 
 ## Sensors
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -38,3 +38,12 @@ tumor_evolution:
         the package for valid values: https://github.com/gmc-norr/tumor-evolution/releases
       type: string
       required: true
+
+notification_email:
+  type: array
+  description: Email addresses to send notifications to
+  items:
+    type: string
+    description: An email address
+  default: []
+  required: true

--- a/rules/send_notification_email.yaml
+++ b/rules/send_notification_email.yaml
@@ -2,7 +2,7 @@
 name: send_notification_email
 pack: gmc_norr_analysis
 description: >
-  Triggers when there is a notification to send via email.
+  Send a notification email
 enabled: true
 
 trigger:

--- a/rules/send_notification_email.yaml
+++ b/rules/send_notification_email.yaml
@@ -1,0 +1,18 @@
+---
+name: send_notification_email
+pack: gmc_norr_analysis
+description: >
+  Triggers when there is a notification to send via email.
+enabled: true
+
+trigger:
+  type: gmc_norr_analysis.email_notification
+
+action:
+  ref: email.send_email
+  parameters:
+    account: SMTP-VLL
+    email_from: stackstorm@regionvasterbotten.se
+    email_to: "{{ trigger.to | to_json_string }}"
+    subject: "{{ trigger.subject }}"
+    message: "{{ trigger.message }}"

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -12,10 +12,15 @@ class TumorEvolutionSensor(PollingSensor):
     def setup(self):
         pass
 
+    def _watch_file_ok(self):
+        return self.watch_file.exists()
+
     def poll(self):
         self.logger.debug(f"looking for requests in {self.watch_file}")
 
-        if not self.watch_file.exists():
+        found_watch_file = self._watch_file_ok()
+
+        if not found_watch_file:
             self.logger.warning("watch file not found, creating it")
             self._reset_watch_file()
             return

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -72,10 +72,11 @@ class TumorEvolutionSensor(PollingSensor):
                 n_dispatched += 1
 
         if n_dispatched == 0:
-            self.logger.info("watch file empty")
+            self.logger.debug("watch file empty")
             return
 
-        self.logger.info(f"dispatched {n_dispatched} request")
+        self.logger.info(f"dispatched {n_dispatched} "
+                         f"request{'' if n_dispatched == 1 else 's'}")
 
         self._reset_watch_file()
 

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -5,7 +5,8 @@ from st2reactor.sensor.base import PollingSensor
 class TumorEvolutionSensor(PollingSensor):
     def __init__(self, sensor_service, config, poll_interval=60):
         super(TumorEvolutionSensor, self).__init__(sensor_service, config, poll_interval)
-        self._original_poll_interval = poll_interval
+        self._original_poll_interval = self.get_poll_interval()
+        self.max_poll_interval = 1200
         self.logger = self.sensor_service.get_logger(__name__)
         self.watch_file = Path(self.config["tumor_evolution"]["watch_file"])
         self.watch_file_instructions = self.config["tumor_evolution"]["watch_file_instructions"]
@@ -18,6 +19,12 @@ class TumorEvolutionSensor(PollingSensor):
             return self.watch_file.exists()
         except OSError:
             raise
+
+    def _increase_poll_interval(self):
+        self.set_poll_interval(min(
+            self.get_poll_interval() * 2,
+            self.max_poll_interval
+        ))
 
     def poll(self):
         self.logger.debug(f"looking for requests in {self.watch_file}")
@@ -35,15 +42,14 @@ class TumorEvolutionSensor(PollingSensor):
                     "message": "Failed to check watch file: %s" % e
                 }
             )
-            self.set_poll_interval(self.get_poll_interval() * 2)
+            self._increase_poll_interval()
             return
-
-        self.set_poll_interval(self._original_poll_interval)
 
         if not found_watch_file:
             self.logger.warning("watch file not found, creating it")
             try:
                 self._reset_watch_file()
+                self.set_poll_interval(self._original_poll_interval)
             except FileNotFoundError as e:
                 self.logger.error(f"failed to create watch file: {e}")
                 self.sensor_service.dispatch(
@@ -55,7 +61,7 @@ class TumorEvolutionSensor(PollingSensor):
                         "message": "Failed to create watch file: %s" % e
                     }
                 )
-                self.set_poll_interval(self.get_poll_interval() * 2)
+                self._increase_poll_interval()
             return
 
         n_dispatched = 0

--- a/sensors/tumor_evolution_sensor.yaml
+++ b/sensors/tumor_evolution_sensor.yaml
@@ -14,3 +14,25 @@ trigger_types:
           type: string
         sheet:
           type: string
+
+  - name: email_notification
+    pack: gmc_norr_analysis
+    description: >
+      Triggers when there is a notification to send via email.
+    payload_schema:
+      type: object
+      properties:
+        to:
+          type: array
+          items:
+            type: string
+            description: "Email address to send notification to"
+          default: []
+        subject:
+          type: string
+          description: "Email subject"
+          required: true
+        message:
+          type: string
+          description: "Email message body"
+          required: true

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -46,9 +46,26 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
         self.assertFalse(
             Path(self.watch_file).exists()
         )
+        original_poll_interval = self.sensor.get_poll_interval()
         self.sensor.poll()
         self.assertFalse(
             Path(self.sensor.config["tumor_evolution"]["watch_file"]).exists()
+        )
+        self.assertTriggerDispatched(
+            trigger="gmc_norr_analysis.notification_email",
+            payload={
+                "to": ["me@mail.com"],
+                "subject": "[TumorEvolutionSensor] Failed to "
+                           "create watch file",
+                "message": "Failed to create watch file: [Errno 2] "
+                           "No such file or directory: "
+                           "'/no/such/path/watch.txt'"
+            }
+        )
+        self.assertFalse(self.watch_file.exists())
+        self.assertEqual(
+            self.sensor.get_poll_interval(),
+            original_poll_interval * 2
         )
 
     def test_missing_mount(self):

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from sensors.tumor_evolution_sensor import TumorEvolutionSensor
+from st2tests.base import BaseSensorTestCase
+import tempfile
+from unittest.mock import Mock
+
+
+class TumorEvolutionSensorTest(BaseSensorTestCase):
+    sensor_cls = TumorEvolutionSensor
+
+    def setUp(self):
+        super(TumorEvolutionSensorTest, self).setUp()
+
+        self.watch_dir = tempfile.TemporaryDirectory()
+        self.watch_file = Path(self.watch_dir.name) / "watch.txt"
+        self.output_dir = tempfile.TemporaryDirectory()
+
+        self._sensor_setup()
+
+    def _sensor_setup(self):
+        self.sensor = self.get_sensor_instance(config={
+            "tumor_evolution": {
+                "output_directory": str(self.output_dir),
+                "watch_file": str(self.watch_file),
+                "watch_file_instructions": "test instructions",
+                "version": "0.5.4"
+            }
+        })
+
+    def test_missing_watch_file(self):
+        self.assertFalse(self.watch_file.exists())
+        self.sensor.poll()
+        self.assertTrue(self.watch_file.exists())
+        self.assertEqual(len(self.get_dispatched_triggers()), 0)
+        with open(self.watch_file) as f:
+            self.assertEqual(
+                f.read(),
+                self.sensor.config["tumor_evolution"]
+                                  ["watch_file_instructions"]
+            )
+
+    def test_missing_watch_file_path(self):
+        self.watch_file = Path("/no/such/path/watch.txt")
+        self._sensor_setup()
+        self.assertFalse(
+            Path(self.watch_file).exists()
+        )
+        self.sensor.poll()
+        self.assertFalse(
+            Path(self.sensor.config["tumor_evolution"]["watch_file"]).exists()
+        )
+
+    def test_missing_mount(self):
+        self._sensor_setup()
+        self.sensor._watch_file_ok = Mock(
+            side_effect=OSError(112, "Host is down", str(self.watch_file))
+        )
+        self.sensor.poll()


### PR DESCRIPTION
This PR addresses a couple of issues whenever files cannot be accessed. The problem was discovered when the host lost a mount point during a maintenance window, and it crashed less than gracefully. Now it's coded a bit more defensively, and it will emit a trigger for an email notification if these issues would arise in the future. To avoid flooding the logs (and peoples' inboxes), I made it so the polling interval increases for each failure, to a certain maximum polling interval (currently 20 min). This is reset once everything is back in business.

Furthermore, the logging was slightly modified to not create unnecessary entries.

Merging this PR will close #14.