### PR TITLE
fix: more general support for windows paths

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -45,4 +45,3 @@ jobs:
         image: rabbitmq:3
         ports:
           - 5672:5672
-

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -38,7 +38,7 @@ jobs:
 
     services:
       mongo:
-        image: mongo:3.4
+        image: mongo:3.6
         ports:
           - 27017:27017
       rabbitmq:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/actions/generate_tumor_evolution_report.sh
+++ b/actions/generate_tumor_evolution_report.sh
@@ -2,19 +2,9 @@
 
 set -euo pipefail
 
-function win_to_unix() {
-    # Right now this only handles paths on G:. This will likely have to
-    # change in a not too distant future.
-    if [[ "$1" == G:* ]]; then
-        sed -e 's#\\#/#g' -e 's#^G:[\\/]Genetik#/mnt/G-Genetik#' <<< "$1"
-    else
-        echo "$1"
-    fi
-}
-
-INPUTFILE=$(win_to_unix "$1")
+INPUTFILE="$1"
 SHEET=$2
-OUTPUTDIR=$(win_to_unix "$3")
+OUTPUTDIR="$3"
 VERSION=$4
 IMAGE="tumor-evolution:${VERSION}"
 

--- a/actions/tumor_evolution.yaml
+++ b/actions/tumor_evolution.yaml
@@ -25,4 +25,3 @@ parameters:
     type: string
     immutable: true
     default: "{{ config_context.tumor_evolution.version }}"
-

--- a/actions/workflows/tumor_evolution.yaml
+++ b/actions/workflows/tumor_evolution.yaml
@@ -27,7 +27,7 @@ tasks:
       - when: <% failed() %>
         publish:
           - log: <% result().stderr %>
-        do: 
+        do:
           - write_log
           - fail
 
@@ -41,4 +41,3 @@ tasks:
 
 output:
   - log: <% ctx().log %>
-

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -6,7 +6,9 @@ tumor_evolution:
       description: >
         Directory where the report should be saved. This can either be an
         absolute path on the StackStorm server, or a Windows path referring
-        to G:.
+        to a drive that has been mounted on the same system where StackStorm
+        is running. E.g., K: should be mounted at /mnt/K-Genetik, G: at
+        /mnt/G-Genetik, etc.
       type: string
       format: uri-reference
       required: true

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 from st2reactor.sensor.base import PollingSensor
 
 
@@ -98,13 +99,27 @@ class TumorEvolutionSensor(PollingSensor):
     def remove_trigger(self, trigger):
         pass
 
+    def win2unix(self, path: str):
+        """
+        Convert a windows path to a unix path.
+
+        This assumes that any windows drive letter has been mounted
+        at /mnt/<drive-letter>-Genetik. For example, G: should be
+        mounted at /mnt/G-Genetik, K: at /mnt/K-Genetik, and so on.
+        """
+        unix_path = path.replace("\\", "/")
+        winre = re.compile("^([GKV]):")
+        if winre.match(unix_path):
+            unix_path = winre.sub("/mnt/\\1-Genetik", unix_path)
+        return unix_path
+
     def _parse_arguments(self, arg_string):
         args = arg_string.split()
 
         if len(args) > 2:
             self.logger.warning("too many arguments, ignoring all but first two")
 
-        excel_file = args[0]
+        excel_file = self.win2unix(args[0])
         sheet = "1"
 
         if len(args) > 1:

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -23,10 +23,43 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
             "tumor_evolution": {
                 "output_directory": str(self.output_dir),
                 "watch_file": str(self.watch_file),
-                "watch_file_instructions": "test instructions",
+                "watch_file_instructions": "# test instructions\n",
                 "version": "0.5.4"
             }
         })
+
+    def test_excel_paths(self):
+        paths = [
+            {
+                "input": "G:\\path\\to\\a\\file.xlsx",
+                "output": "/mnt/G-Genetik/path/to/a/file.xlsx",
+            },
+            {
+                "input": "K:\\path\\to\\a\\file.xlsx",
+                "output": "/mnt/K-Genetik/path/to/a/file.xlsx",
+            },
+            {
+                "input": "V:\\path\\to\\a\\file.xlsx",
+                "output": "/mnt/V-Genetik/path/to/a/file.xlsx",
+            },
+            {
+                "input": "/storage/path/to/excel/file",
+                "output": "/storage/path/to/excel/file",
+            },
+        ]
+        
+        for i, p in enumerate(paths, start=1):
+            with open(self.watch_file, "a") as wf:
+                wf.write(p["input"])
+            self.sensor.poll()
+            self.assertEqual(len(self.get_dispatched_triggers()), i)
+            self.assertTriggerDispatched(
+                trigger="gmc_norr_analysis.tumor_evolution_request",
+                payload=dict(
+                    excel_file=p["output"],
+                    sheet="1",
+                )
+            )
 
     def test_missing_watch_file(self):
         self.assertFalse(self.watch_file.exists())

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -47,7 +47,7 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
                 "output": "/storage/path/to/excel/file",
             },
         ]
-        
+
         for i, p in enumerate(paths, start=1):
             with open(self.watch_file, "a") as wf:
                 wf.write(p["input"])


### PR DESCRIPTION
This PR moves the translation of windows paths to unix paths from the tumor evolution action to the the sensor. This makes it a bit more general (but still requires a specific mounting scheme), and it will also make it possible for any other actions to act on this trigger without having to do the translation themselves.

In order to get these things to work, I also added pre-commit hooks (same as for st2-seqdata), and also updated mongo for the Github Actions workflow.