### PR TITLE
fix: bug in excel file paths

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -108,9 +108,9 @@ class TumorEvolutionSensor(PollingSensor):
         mounted at /mnt/G-Genetik, K: at /mnt/K-Genetik, and so on.
         """
         unix_path = path.replace("\\", "/")
-        winre = re.compile("^([GKV]):")
+        winre = re.compile(r"^([GKV]):/(Genetik)")
         if winre.match(unix_path):
-            unix_path = winre.sub("/mnt/\\1-Genetik", unix_path)
+            unix_path = winre.sub("/mnt/\\1-\\2", unix_path)
         return unix_path
 
     def _parse_arguments(self, arg_string):

--- a/sensors/tumor_evolution_sensor.py
+++ b/sensors/tumor_evolution_sensor.py
@@ -107,7 +107,7 @@ class TumorEvolutionSensor(PollingSensor):
         at /mnt/<drive-letter>-Genetik. For example, G: should be
         mounted at /mnt/G-Genetik, K: at /mnt/K-Genetik, and so on.
         """
-        unix_path = path.replace("\\", "/")
+        unix_path = path.strip('"').replace("\\", "/")
         winre = re.compile(r"^([GKV]):/(Genetik)")
         if winre.match(unix_path):
             unix_path = winre.sub("/mnt/\\1-\\2", unix_path)

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -31,15 +31,15 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
     def test_excel_paths(self):
         paths = [
             {
-                "input": "G:\\path\\to\\a\\file.xlsx",
+                "input": "G:\\Genetik\\path\\to\\a\\file.xlsx",
                 "output": "/mnt/G-Genetik/path/to/a/file.xlsx",
             },
             {
-                "input": "K:\\path\\to\\a\\file.xlsx",
+                "input": "K:\\Genetik\\path\\to\\a\\file.xlsx",
                 "output": "/mnt/K-Genetik/path/to/a/file.xlsx",
             },
             {
-                "input": "V:\\path\\to\\a\\file.xlsx",
+                "input": "V:\\Genetik\\path\\to\\a\\file.xlsx",
                 "output": "/mnt/V-Genetik/path/to/a/file.xlsx",
             },
             {

--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -35,6 +35,10 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
                 "output": "/mnt/G-Genetik/path/to/a/file.xlsx",
             },
             {
+                "input": "\"G:\\Genetik\\path\\to\\another\\file.xlsx\"",
+                "output": "/mnt/G-Genetik/path/to/another/file.xlsx",
+            },
+            {
                 "input": "K:\\Genetik\\path\\to\\a\\file.xlsx",
                 "output": "/mnt/K-Genetik/path/to/a/file.xlsx",
             },


### PR DESCRIPTION
The previous bug fix introduced a different bug where "Genetik" was added twice in the translated path. This PR addresses this. In addition, I also added support for quoted paths in the watch file.