### PR TITLE
fix: catch encoding errors when reading watch file

### DIFF
--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -195,3 +195,16 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
             self.sensor.get_poll_interval(),
             self.sensor.max_poll_interval
         )
+
+    def test_invalid_encoding(self):
+        with open(self.watch_file, "bw") as f:
+            f.write("nedlåst".encode("latin-1"))
+
+        self.sensor.poll()
+        self.assertEqual(len(self.get_dispatched_triggers()), 1)
+        self.assertTriggerDispatched("gmc_norr_analysis.email_notification")
+        trigger = self.get_dispatched_triggers()[0]
+        self.assertEqual(
+            trigger["payload"]["subject"],
+            "[TumorEvolutionSensor] Error reading watch file",
+        )


### PR DESCRIPTION
If the watch file is written using a different encoding than UTF-8, the sensor might crash depending on the characters in the file. This PR addresses this by manually decoding each line in the file and bailing out with an error if the decoding fails.

In working on this, I started thinking that this type of parsing should probably be delegated to an action that is part of the workflow. This way these types of errors will be logged much more clearly, and it will also be easier to act upon it automatically. The sensor should then do minimal work, i.e. only check if there are lines in the file that could be processed. Everything else is done by the workflow. I created a separate issue for this: #28.