### PR TITLE
fix: properly reset polling intervall on error recovery

### DIFF
--- a/tests/test_sensor_tumor_evolution_sensor.py
+++ b/tests/test_sensor_tumor_evolution_sensor.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from sensors.tumor_evolution_sensor import TumorEvolutionSensor
 from st2tests.base import BaseSensorTestCase
@@ -18,29 +19,31 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
         self._sensor_setup()
 
     def _sensor_setup(self):
-        self.sensor = self.get_sensor_instance(config={
-            "notification_email": ["me@mail.com"],
-            "tumor_evolution": {
-                "output_directory": str(self.output_dir),
-                "watch_file": str(self.watch_file),
-                "watch_file_instructions": "# test instructions\n",
-                "version": "0.5.4"
-            },
-            "mounts": [
-                {
-                    "win": "G:\\Genetik",
-                    "unix": "/mnt/G-Genetik",
+        self.sensor = self.get_sensor_instance(
+            config={
+                "notification_email": ["me@mail.com"],
+                "tumor_evolution": {
+                    "output_directory": str(self.output_dir),
+                    "watch_file": str(self.watch_file),
+                    "watch_file_instructions": "# test instructions\n",
+                    "version": "0.5.4",
                 },
-                {
-                    "win": "K:\\Genetik",
-                    "unix": "/mnt/testmount",
-                },
-                {
-                    "win": "V:\\Genetik",
-                    "unix": "/mnt/V-Genetik",
-                },
-            ],
-        })
+                "mounts": [
+                    {
+                        "win": "G:\\Genetik",
+                        "unix": "/mnt/G-Genetik",
+                    },
+                    {
+                        "win": "K:\\Genetik",
+                        "unix": "/mnt/testmount",
+                    },
+                    {
+                        "win": "V:\\Genetik",
+                        "unix": "/mnt/V-Genetik",
+                    },
+                ],
+            }
+        )
 
     def test_excel_paths(self):
         paths = [
@@ -53,7 +56,7 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
                 "output": "/mnt/G-Genetik/path/To/A/CaseSensitiveFile.xlsx",
             },
             {
-                "input": "\"G:\\Genetik\\path\\to\\another\\file.xlsx\"",
+                "input": '"G:\\Genetik\\path\\to\\another\\file.xlsx"',
                 "output": "/mnt/G-Genetik/path/to/another/file.xlsx",
             },
             {
@@ -80,7 +83,7 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
                 payload=dict(
                     excel_file=p["output"],
                     sheet="1",
-                )
+                ),
             )
 
     def test_missing_watch_file(self):
@@ -90,38 +93,31 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
         self.assertEqual(len(self.get_dispatched_triggers()), 0)
         with open(self.watch_file) as f:
             self.assertEqual(
-                f.read(),
-                self.sensor.config["tumor_evolution"]
-                                  ["watch_file_instructions"]
+                f.read(
+                ), self.sensor.config["tumor_evolution"]["watch_file_instructions"]
             )
 
     def test_missing_watch_file_path(self):
         self.watch_file = Path("/no/such/path/watch.txt")
         self._sensor_setup()
-        self.assertFalse(
-            Path(self.watch_file).exists()
-        )
+        self.assertFalse(Path(self.watch_file).exists())
         original_poll_interval = self.sensor.get_poll_interval()
         self.sensor.poll()
         self.assertFalse(
-            Path(self.sensor.config["tumor_evolution"]["watch_file"]).exists()
-        )
+            Path(self.sensor.config["tumor_evolution"]["watch_file"]).exists())
         self.assertTriggerDispatched(
             trigger="gmc_norr_analysis.email_notification",
             payload={
                 "to": ["me@mail.com"],
-                "subject": "[TumorEvolutionSensor] Failed to "
-                           "create watch file",
+                "subject": "[TumorEvolutionSensor] Failed to create watch file",
                 "message": "Failed to create watch file: [Errno 2] "
-                           "No such file or directory: "
-                           "'/no/such/path/watch.txt'"
-            }
+                "No such file or directory: "
+                "'/no/such/path/watch.txt'",
+            },
         )
         self.assertFalse(self.watch_file.exists())
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 2
-        )
+        self.assertEqual(self.sensor.get_poll_interval(),
+                         original_poll_interval * 2)
 
     def test_missing_mount(self):
         self._sensor_setup()
@@ -131,16 +127,13 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
         )
         original_poll_interval = self.sensor.get_poll_interval()
         self.sensor.poll()
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 2
-        )
+        self.assertEqual(self.sensor.get_poll_interval(),
+                         original_poll_interval * 2)
         self.assertTriggerDispatched("gmc_norr_analysis.email_notification")
         trigger = self.get_dispatched_triggers()[0]
         self.assertEqual(
             trigger["payload"]["message"],
-            "Failed to check watch file: [Errno 112] "
-            f"Host is down: '{self.watch_file}'"
+            f"Failed to check watch file: [Errno 112] Host is down: '{self.watch_file}'",
         )
 
         self.sensor._watch_file_ok = original_func
@@ -150,10 +143,8 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
         self.sensor.poll()
         self.assertTrue(self.watch_file.exists())
         self.assertEqual(len(self.get_dispatched_triggers()), 1)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval
-        )
+        self.assertEqual(self.sensor.get_poll_interval(),
+                         original_poll_interval)
 
     def test_max_polling_interval(self):
         self.watch_file = Path("/no/such/path/watch.txt")
@@ -161,40 +152,54 @@ class TumorEvolutionSensorTest(BaseSensorTestCase):
 
         original_poll_interval = self.sensor.get_poll_interval()
 
-        self.sensor.poll()
-        self.assertEqual(len(self.get_dispatched_triggers()), 1)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 2
+        for i in range(5):
+            self.sensor.poll()
+            self.assertEqual(len(self.get_dispatched_triggers()), i + 1)
+            self.assertEqual(
+                self.sensor.get_poll_interval(),
+                min(self.sensor.max_poll_interval,
+                    original_poll_interval * 2 * 2**i),
+            )
+
+    def test_poll_interval_reset(self):
+        self._sensor_setup()
+        original_poll_interval = self.sensor.get_poll_interval()
+        self.assertEqual(original_poll_interval, 60)
+
+        # File has an entry to start with...
+        with open(self.watch_file, "w") as f:
+            f.write("/path/to/excel_file.xlsx")
+
+        # ... but something is wrong...
+        self.sensor._watch_file_ok = Mock(
+            side_effect=OSError(
+                126, "Required key not available", str(self.watch_file))
         )
 
         self.sensor.poll()
-        self.assertEqual(len(self.get_dispatched_triggers()), 2)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 4
+        # ... so an email trigger should be dispatched...
+        self.assertTriggerDispatched(
+            trigger="gmc_norr_analysis.email_notification",
         )
+        # ... and the polling interval increased
+        self.assertEqual(self.sensor.get_poll_interval(),
+                         original_poll_interval * 2)
+
+        # Things are now ok...
+        self.sensor._watch_file_ok = Mock(return_value=True)
 
         self.sensor.poll()
-        self.assertEqual(len(self.get_dispatched_triggers()), 3)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 8
+        # ... a report generation trigger should be dispatched...
+        self.assertTriggerDispatched(
+            trigger="gmc_norr_analysis.tumor_evolution_request",
+            payload={
+                "excel_file": "/path/to/excel_file.xlsx",
+                "sheet": "1",
+            },
         )
-
-        self.sensor.poll()
-        self.assertEqual(len(self.get_dispatched_triggers()), 4)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            original_poll_interval * 16
-        )
-
-        self.sensor.poll()
-        self.assertEqual(len(self.get_dispatched_triggers()), 5)
-        self.assertEqual(
-            self.sensor.get_poll_interval(),
-            self.sensor.max_poll_interval
-        )
+        # ... and the polling interval should be reset
+        self.assertEqual(self.sensor.get_poll_interval(),
+                         original_poll_interval)
 
     def test_invalid_encoding(self):
         with open(self.watch_file, "bw") as f:


### PR DESCRIPTION
This PR addresses an issue where the polling interval wouldn't be reset for a certain condition. The situation occurred when the watch file existed, but the path couldn't be checked due to some file system issue. After recovering from this issue, the file still existed, and since the poll interval reset only occurred when resetting the watch file, and this in turn only occurred when the file didn't exist, the polling interval was never reset. Here this issue is addressed.

This closes #31 