### PR TITLE
feat: add `get pipeline input files` (for Cleve) action

### DIFF
--- a/actions/get_pipeline_input_files.py
+++ b/actions/get_pipeline_input_files.py
@@ -1,0 +1,22 @@
+from st2common.runners.base_action import Action
+
+
+def get_rd_input_files(sample_id, analysis_id, fastq_files):
+    input_files = []
+    for file in fastq_files["R1"] + fastq_files["R2"]:
+        input_files.append({'analysis_id': analysis_id, 'name':  file.split('/')[-1],
+                            'level': 'sample', 'type': 'fastq', 'parent_id': sample_id})
+    input_files.append({'analysis_id': analysis_id, 'parent_id': sample_id, 'level': 'sample',
+                        'type': 'text', 'name': 'samplesheet.csv'})
+    return input_files
+
+
+class GetPipelineInputFilesAction(Action):
+    def run(self, pipeline, fastq_files, analysis_ids, sample_id, normal_sample_id,
+            mother_sample_id, father_sample_id):
+        if pipeline == "nf-core/raredisease":
+            input_files = get_rd_input_files(sample_id, analysis_ids[sample_id],
+                                             fastq_files[sample_id])
+        else:
+            return (False, f"Pipeline not supported: {pipeline}")
+        return (True, input_files)

--- a/actions/get_pipeline_input_files.py
+++ b/actions/get_pipeline_input_files.py
@@ -6,8 +6,6 @@ def get_rd_input_files(sample_id, analysis_id, fastq_files):
     for file in fastq_files["R1"] + fastq_files["R2"]:
         input_files.append({'analysis_id': analysis_id, 'name':  file.split('/')[-1],
                             'level': 'sample', 'type': 'fastq', 'parent_id': sample_id})
-    input_files.append({'analysis_id': analysis_id, 'parent_id': sample_id, 'level': 'sample',
-                        'type': 'text', 'name': 'samplesheet.csv'})
     return input_files
 
 

--- a/actions/get_pipeline_input_files.py
+++ b/actions/get_pipeline_input_files.py
@@ -12,8 +12,7 @@ def get_rd_input_files(sample_id, analysis_id, fastq_files):
 
 
 class GetPipelineInputFilesAction(Action):
-    def run(self, pipeline, fastq_files, analysis_ids, sample_id, normal_sample_id,
-            mother_sample_id, father_sample_id):
+    def run(self, pipeline, fastq_files, analysis_ids, sample_id):
         if pipeline == "nf-core/raredisease":
             input_files = get_rd_input_files(sample_id, analysis_ids[sample_id],
                                              fastq_files[sample_id])

--- a/actions/get_pipeline_input_files.yaml
+++ b/actions/get_pipeline_input_files.yaml
@@ -22,7 +22,7 @@ parameters:
     required: true
     position: 2
   sample_id:
-    description: The ID of the main sample (the only sample, tumor sample or proband)
+    description: The ID of the main sample
     type: string
     required: true
     position: 3

--- a/actions/get_pipeline_input_files.yaml
+++ b/actions/get_pipeline_input_files.yaml
@@ -26,18 +26,3 @@ parameters:
     type: string
     required: true
     position: 3
-  normal_sample_id:
-    description: The ID of the normal sample
-    type: string
-    required: false
-    position: 4
-  mother_sample_id:
-    description: The ID of the mother sample (in case of a trio)
-    type: string
-    required: false
-    position: 5
-  father_sample_id:
-    description: The ID of the father sample (in case of a trio)
-    type: string
-    required: false
-    position: 6

--- a/actions/get_pipeline_input_files.yaml
+++ b/actions/get_pipeline_input_files.yaml
@@ -1,0 +1,43 @@
+name: get_pipeline_input_files
+pack: gmc_norr_analysis
+description: Give the input files for a downstream analysis in a format that Cleve can accept
+runner_type: python-script
+entry_point: get_pipeline_input_files.py
+enabled: true
+
+parameters:
+  pipeline:
+    description: The pipeline to generate input files for Cleve for
+    type: string
+    required: true
+    position: 0
+  fastq_files:
+    description: An object of the fastq files used as input, with the sample IDs as keys
+    type: object
+    required: true
+    position: 1
+  analysis_ids:
+    description: The ID of the analysis that generated the fastq files of the respective samples
+    type: object
+    required: true
+    position: 2
+  sample_id:
+    description: The ID of the main sample (the only sample, tumor sample or proband)
+    type: string
+    required: true
+    position: 3
+  normal_sample_id:
+    description: The ID of the normal sample
+    type: string
+    required: false
+    position: 4
+  mother_sample_id:
+    description: The ID of the mother sample (in case of a trio)
+    type: string
+    required: false
+    position: 5
+  father_sample_id:
+    description: The ID of the father sample (in case of a trio)
+    type: string
+    required: false
+    position: 6


### PR DESCRIPTION
For workflow that starts plumber (and adds the analysis to Cleve to get the analysis id). It's straightforward enough for the raredisease pipeline, but it's going to be more complicated for when we need more than ones sample id. For trios we're going to need sample ids for the mother and father samples, and we have the normal/tumor pairs for others....