### PR TITLE
fix: escape the message from plumber

### DIFF
--- a/rules/email_plumber_end.yaml
+++ b/rules/email_plumber_end.yaml
@@ -22,6 +22,6 @@ action:
     trigger_name: gmc_norr_analysis.email_notification
     payload:
       subject: "{{ trigger.body.pipeline }} in {{ trigger.body.workdir }}"
-      message: "{{ trigger.body.message }}\n\n
+      message: "{{ trigger.body.message | json_escape }}\n\n
         Success: {{ trigger.body.success }}\n\n
         Error: {{ trigger.body.error }}"


### PR DESCRIPTION
The message field in the plumber webhook can contain newlines, and it seems that stackstorm decodes this twice, resulting in orjson throwing a fit. This addresses the issue by escaping the message in the rule that passes on this message.