### PR TITLE
fix: Formating of pipeline output files, with correct level

### DIFF
--- a/actions/get_pipeline_output_files.py
+++ b/actions/get_pipeline_output_files.py
@@ -4,13 +4,13 @@ from st2common.runners.base_action import Action
 def get_rd_output_files(sample_id, case_id):
     output_files = [
         {'path': 'raredisease_results/multiqc/multiqc_report.html',
-         'level': 'sample', 'type': 'html', 'parent_id': sample_id},
+         'level': 'case', 'type': 'html', 'parent_id': sample_id},
         {'path': f'raredisease_results/peddy/{case_id}.peddy.ped',
-         'level': 'sample', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': sample_id},
         {'path': f'raredisease_results/peddy/{case_id}.sex_check.csv',
-         'level': 'sample', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': sample_id},
         {'path': f'raredisease_results/peddy/{case_id}.ped_check.csv',
-         'level': 'sample', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': sample_id},
         {'path': f'raredisease_results/alignment/{sample_id}_sorted_md.bam',
          'level': 'sample', 'type': 'bam', 'parent_id': sample_id},
         {'path': f'raredisease_results/qc_bam/{sample_id}_mosdepth.per-base.d4',
@@ -22,11 +22,11 @@ def get_rd_output_files(sample_id, case_id):
          + f'{sample_id}_tidditcov_chr*.png',
          'level': 'sample', 'type': 'png', 'parent_id': sample_id},
         {'path': f'raredisease_results/smncopynumbercaller/out/{case_id}_smncopynumbercaller.tsv',
-         'level': 'sample', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': sample_id},
         {'path': f'raredisease_results/rank_and_filter/{case_id}_snv_ranked_clinical.vcf.gz',
-         'level': 'sample', 'type': 'vcf_snv', 'parent_id': sample_id},
+         'level': 'case', 'type': 'vcf_snv', 'parent_id': sample_id},
         {'path': f'raredisease_results/rank_and_filter/{case_id}_snv_ranked_research.vcf.gz',
-         'level': 'sample', 'type': 'vcf_snv', 'parent_id': sample_id}
+         'level': 'case', 'type': 'vcf_snv', 'parent_id': sample_id}
          ]
     return output_files
 

--- a/actions/get_pipeline_output_files.py
+++ b/actions/get_pipeline_output_files.py
@@ -4,13 +4,13 @@ from st2common.runners.base_action import Action
 def get_rd_output_files(sample_id, case_id):
     output_files = [
         {'path': 'raredisease_results/multiqc/multiqc_report.html',
-         'level': 'case', 'type': 'html', 'parent_id': sample_id},
+         'level': 'case', 'type': 'html', 'parent_id': case_id},
         {'path': f'raredisease_results/peddy/{case_id}.peddy.ped',
-         'level': 'case', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': case_id},
         {'path': f'raredisease_results/peddy/{case_id}.sex_check.csv',
-         'level': 'case', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': case_id},
         {'path': f'raredisease_results/peddy/{case_id}.ped_check.csv',
-         'level': 'case', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': case_id},
         {'path': f'raredisease_results/alignment/{sample_id}_sorted_md.bam',
          'level': 'sample', 'type': 'bam', 'parent_id': sample_id},
         {'path': f'raredisease_results/qc_bam/{sample_id}_mosdepth.per-base.d4',
@@ -22,11 +22,11 @@ def get_rd_output_files(sample_id, case_id):
          + f'{sample_id}_tidditcov_chr*.png',
          'level': 'sample', 'type': 'png', 'parent_id': sample_id},
         {'path': f'raredisease_results/smncopynumbercaller/out/{case_id}_smncopynumbercaller.tsv',
-         'level': 'case', 'type': 'text', 'parent_id': sample_id},
+         'level': 'case', 'type': 'text', 'parent_id': case_id},
         {'path': f'raredisease_results/rank_and_filter/{case_id}_snv_ranked_clinical.vcf.gz',
-         'level': 'case', 'type': 'vcf_snv', 'parent_id': sample_id},
+         'level': 'case', 'type': 'vcf_snv', 'parent_id': case_id},
         {'path': f'raredisease_results/rank_and_filter/{case_id}_snv_ranked_research.vcf.gz',
-         'level': 'case', 'type': 'vcf_snv', 'parent_id': sample_id}
+         'level': 'case', 'type': 'vcf_snv', 'parent_id': case_id}
          ]
     return output_files
 


### PR DESCRIPTION
Fix so that pipeline files have correct ``` level ``` in cleve