### PR TITLE
feat: add `prepare_twist_solid` workflow and support for it in `plumber_analysis`

### DIFF
--- a/actions/plumber_analysis.yaml
+++ b/actions/plumber_analysis.yaml
@@ -1,0 +1,45 @@
+---
+name: plumber_analysis
+pack: gmc_norr_analysis
+description: Workflow to run downstream analysis of a sample with plumber
+runner_type: orquesta
+entry_point: workflows/plumber_analysis.yaml
+enabled: true
+
+parameters:
+  sample_id:
+    description: The ID of the sample to analyze
+    type: string
+    required: true
+  run_id:
+    description: The ID of the run the sample belongs to
+    type: string
+    required: true
+  run_path:
+    description: The path to the sequencing run
+    type: string
+    required: true
+  analysis_id:
+    description: The ID of the analysis that generated the sample's fastq files
+    type: string
+    required: true
+  plumber_env:
+    type: object
+    secret: true
+    required: true
+    default:
+      PLUMBER_WEBHOOK_URL: "{{st2kv.system.api_url}}/webhooks/plumber"
+      PLUMBER_WEBHOOK_API_KEY: "St2-Api-Key={{ st2kv.system.plumber_api_key | decrypt_kv }}"
+  plumber_host:
+    description: Host to run plumber on
+    type: string
+    default: "{{config_context.plumber.host}}"
+  supported_profiles:
+    description: Supported iGene test profiles.
+    type: array
+    items:
+      type: string
+    immutable: true
+    default:
+      - WGSRareDisease_1
+      - PanelTwistSolid_0.23.0

--- a/actions/prepare_twist_solid.yaml
+++ b/actions/prepare_twist_solid.yaml
@@ -24,3 +24,7 @@ parameters:
     type: string
     required: true
     default: "{{ config_context.plumber.twist_solid_dir }}"
+  host:
+    description: The host where to run hydra-genetics on
+    type: string
+    required: true

--- a/actions/prepare_twist_solid.yaml
+++ b/actions/prepare_twist_solid.yaml
@@ -23,4 +23,4 @@ parameters:
     description: The path to the directory where we have to start snakemake analyses from
     type: string
     required: true
-    default: /storage/userdata/gms_solid
+    default: "{{ config_context.plumber.twist_solid_dir }}"

--- a/actions/prepare_twist_solid.yaml
+++ b/actions/prepare_twist_solid.yaml
@@ -1,0 +1,26 @@
+---
+name: prepare_twist_solid
+pack: gmc_norr_analysis
+description: Workflow for preparing to start a Twist Solid analysis of a sample with plumber
+runner_type: orquesta
+entry_point: workflows/prepare_twist_solid.yaml
+enabled: true
+
+parameters:
+  sample_id:
+    description: The ID of the sample
+    type: string
+    required: true
+  run_id:
+    description: The ID of the run
+    type: string
+    required: true
+  fastq_files:
+    description: The sample's fastq files
+    type: array
+    required: true
+  twist_solid_dir:
+    description: The path to the directory where we have to start snakemake analyses from
+    type: string
+    required: true
+    default: /storage/userdata/gms_solid

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -113,7 +113,7 @@ tasks:
     next:
       - when: "{{ ctx().pipeline == 'nf-core/raredisease' }}"
         publish:
-          - output_dir: "{{ ctx().run_path.rstrip('/') }}/{{ ctx().test_profile }}/{{ ctx().sample_id }}"
+          - output_dir: "{{ ctx().run_path.rstrip('/') }}/{{ ctx().pipeline.split('/')[-1] }}/{{ ctx().sample_id }}"
         do:
           rd_check_flowcell
       - when: "{{ ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -218,7 +218,7 @@ tasks:
       - when: "{{ failed() }}"
         publish:
           msg="Failed to output directory.
-          {{ result() | to_json_string }}"
+          {{ result().result.output.error }}"
         do: report_failure
 
   format_cleve_input_files: # the workflow reconnects here

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -212,7 +212,7 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         publish:
-          output_dir: <% result().result.output.output_dir %>
+          output_dir: <% result().result.output.work_dir %>
         do:
           format_cleve_input_files
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -212,7 +212,7 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         publish:
-          - output_dir: <% result().result.output.work_dir %>
+          - output_dir: <% result().output.work_dir %>
         do:
           format_cleve_input_files
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -212,7 +212,7 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         publish:
-          output_dir: <% result().result.output.work_dir %>
+          - output_dir: <% result().result.output.work_dir %>
         do:
           format_cleve_input_files
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -119,7 +119,7 @@ tasks:
       - when: "{{ ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
         do:
           gms_solid_workflow
-      - when: "{{ ctx().pipeline != 'nf-core/raredisease'}}"
+      - when: "{{ ctx().pipeline != 'nf-core/raredisease' and ctx().pipeline != 'genomic-medicine-sweden/Twist_Solid'}}"
         publish:
           msg="Unsupported pipeline {{ ctx().pipeline }}"
         do:

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -207,6 +207,7 @@ tasks:
       sample_id: <% ctx().sample_id %>
       run_id: <% ctx().run_id %>
       fastq_files: "{{ ctx().fastq_files.get(ctx().sample_id).R1 + ctx().fastq_files.get(ctx().sample_id).R2 }}"
+      host: <% ctx().plumber_host %>
       # twist_solid_dir: "use default in action or ask seqdata? Which config?"
     next:
       - when: "{{ succeeded() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -218,7 +218,7 @@ tasks:
       - when: "{{ failed() }}"
         publish:
           msg="Failed to output directory.
-          {{ result().result.output.error }}"
+          {{ result() | to_json_string }}"
         do: report_failure
 
   format_cleve_input_files: # the workflow reconnects here

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -208,7 +208,6 @@ tasks:
       run_id: <% ctx().run_id %>
       fastq_files: "{{ ctx().fastq_files.get(ctx().sample_id).R1 + ctx().fastq_files.get(ctx().sample_id).R2 }}"
       host: <% ctx().plumber_host %>
-      # twist_solid_dir: "use default in action or ask seqdata? Which config?"
     next:
       - when: "{{ succeeded() }}"
         publish:

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -1,0 +1,310 @@
+version: "1.0"
+
+description: Run downstream analysis of a sample with plumber.
+input:
+  - sample_id
+  - run_id
+  - run_path
+  - analysis_id
+  - plumber_host
+  - plumber_env
+  - supported_profiles
+
+vars:
+  - msg:
+  - test_profile:
+  - mother_sample_id:
+  - father_sample_id:
+  - sex:
+  - output_dir:
+  - pipeline:
+  - pipeline_version:
+  - pipeline_profile:
+  - plumber_config_version:
+  - plumber_cmd:
+  - case_id:
+  - fastq_files:
+  - analysis_ids:
+  - input_files:
+  - pid:
+
+output:
+  - msg: <% ctx().msg %>
+
+tasks:
+  get_sample_data:
+    action: igene.get_sample
+    input:
+      sample_id: <% ctx().sample_id %>
+    retry:
+      when: "{{ failed() }}"
+      delay: 1
+      count: 2
+    next:
+      - when: "{{ succeeded() and result().result.body.TestProfile in ctx().supported_profiles }}"
+        publish:
+          - test_profile: <% result().result.body.TestProfile %>
+          - mother_sample_id: <% result().result.body.Mother %>
+          - father_sample_id: <% result().result.body.Father %>
+          - sex: <% result().result.body.Sex %>
+        do:
+          get_fastq_files
+      - when: "{{ succeeded() and result().result.body.TestProfile not in ctx().supported_profiles }}"
+        publish:
+          msg="{{ result().result.body.TestProfile }} not supported in automation."
+        do: noop
+      - when: "{{ failed() and not ctx().sample_id.startswith('Seq') }}"
+        publish:
+          msg="Failed to get sample data from the iGene API for {{ ctx().sample_id }}.
+          {{ result() | to_json_string }}"
+        do: noop
+      - when: "{{ failed() and ctx().sample_id.startswith('Seq') }}"
+        publish:
+          msg="Failed to get sample data from the iGene API.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  get_fastq_files: #if it's a trio or something with normal/tumor, we will fastq files for all. Make a new action at that point?
+    action: cleve.get_analysis_files
+    input:
+      analysis_id: <% ctx().analysis_id %>
+      type: "fastq"
+      level: "sample"
+      parent_id: <% ctx().sample_id %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - fastq_files:
+              <% ctx().sample_id %>:
+                R1: <% result().result.body.where($.path.matches("_R1_")).select($.path).orderBy($) %>
+                R2: <% result().result.body.where($.path.matches("_R2_")).select($.path).orderBy($) %>
+        do:
+          get_plumber_arguments
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to get fastq files from Cleve.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  get_plumber_arguments:
+    action: gmc_norr_analysis.get_plumber_arguments
+    input:
+       test_profile: <% ctx().test_profile %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - pipeline: <% result().result.Pipeline %>
+          - pipeline_version: <% result().result.Version %>
+          - pipeline_profile: <% result().result.Profile %>
+          - plumber_config_version: <% result().result.ConfigVersion %>
+        do:
+          divide_workflow
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to get TestProfile configuration.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  divide_workflow:
+    action: core.noop
+    next:
+      - when: "{{ ctx().pipeline == 'nf-core/raredisease' }}"
+        publish:
+          - output_dir: "{{ ctx().run_path.rstrip('/') }}/{{ ctx().test_profile }}/{{ ctx().sample_id }}"
+        do:
+          rd_check_flowcell
+      - when: "{{ ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
+        do:
+          gms_solid_workflow
+      - when: "{{ ctx().pipeline != 'nf-core/raredisease'}}"
+        publish:
+          msg="Unsupported pipeline {{ ctx().pipeline }}"
+        do:
+          report_failure
+
+  rd_check_flowcell: # stop the workflow if it's a prerun of the sequencing
+    action: cleve.get_runs
+    input:
+      run_id: <% ctx().run_id %>
+    retry:
+      when: "{{ failed() }}"
+      delay: 1
+      count: 2
+    next:
+      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
+        do:
+          rd_prepare_output_folder
+      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name = '1.5B' %>
+        publish:
+          msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
+        do:
+          noop
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to get number of reads for sample from Cleve.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  rd_prepare_output_folder:
+    action: core.local
+    input:
+      cmd:  "mkdir -p <% ctx().output_dir %>"
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          rd_make_case_id
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to output directory.
+          {{ result() | to_json_string }}"
+        do: report_failure
+
+  rd_make_case_id:
+    action: gmc_norr_analysis.make_case_id
+    input:
+      samples:
+        - <% ctx().sample_id %>
+        - "{% if ctx().mother_sample_id is not none %}{{ ctx().mother_sample_id }}{% endif %}"
+        - "{% if ctx().father_sample_id is not none %}{{ ctx().father_sample_id }}{% endif %}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - case_id: <% result().result %>
+        do:
+          rd_make_input_files
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to generate case id.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  rd_make_input_files:
+    action: gmc_norr_analysis.make_raredisease_samplesheet
+    input:
+      sample_id: <% ctx().sample_id %>
+      case_id: <% ctx().case_id %>
+      sex: <% ctx().sex %>
+      fastq_r1: "{{ ctx().fastq_files.get(ctx().sample_id).R1 }}"
+      fastq_r2: "{{ ctx().fastq_files.get(ctx().sample_id).R2 }}"
+      out_dir: <% ctx().output_dir %>
+    next:
+      - when: "{{ succeeded() }}"
+        do: format_cleve_input_files
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to make rare-disease samplesheet.
+          {{ result() | to_json_string }}"
+        do: report_failure
+
+  gms_solid_workflow:
+    action: gmc_norr_analysis.prepare_twist_solid
+    input:
+      sample_id: <% ctx().sample_id %>
+      run_id: <% ctx().run_id %>
+      fastq_files: "{{ ctx().fastq_files.get(ctx().sample_id).R1 + ctx().fastq_files.get(ctx().sample_id).R2 }}"
+      # twist_solid_dir: "use default in action or ask seqdata? Which config?"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          output_dir: <% result().result.output.output_dir %>
+        do:
+          format_cleve_input_files
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to output directory.
+          {{ result() | to_json_string }}"
+        do: report_failure
+
+  format_cleve_input_files: # the workflow reconnects here
+    action: gmc_norr_analysis.get_pipeline_input_files
+    input:
+      pipeline: <% ctx().pipeline %>
+      sample_id: <% ctx().sample_id %>
+      fastq_files: <% ctx().fastq_files %>
+      analysis_ids:
+        "{{ ctx().sample_id }}": "{{ ctx().analysis_id }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          input_files="{{ result().result }}"
+        do:
+          add_plumber_analysis_to_cleve
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to format {{ ctx().pipeline }} input files for Cleve.
+            {{ result().result }} "
+        do:
+          - report_failure
+
+  add_plumber_analysis_to_cleve:
+    action: cleve.add_analysis
+    input:
+      run_id: <% ctx().run_id %>
+      state: pending
+      path: <% ctx().output_dir %>
+      software: <% ctx().pipeline %>
+      software_version: <% ctx().pipeline_version %>
+      input_files: <% ctx().input_files %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - plumber_analysis_id: <% result().result.body.analysis_id %>
+        do:
+          start_plumber
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to add {{ ctx().pipeline }} analysis to Cleve
+            {{ result().stderr }}"
+        do:
+          - report_failure
+
+  start_plumber:
+    action: core.remote
+    input:
+      cmd: "nohup plumber run <% ctx().pipeline %>
+        --version <% ctx().pipeline_version %> --config-version <% ctx().plumber_config_version %>
+        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> &> plumber.log & echo $!"
+      cwd: <% ctx().output_dir %>
+      hosts: <% ctx().plumber_host %>
+      env: <% ctx().plumber_env %>
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to connect to remote to start plumber.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+      - when: "{{ succeeded() }}"
+        publish:
+          - pid: "{{ result().get((result().keys() | list | first)).get('stdout') }}"
+        do: check_progress
+
+  check_progress:
+    action: core.remote
+    delay: 30
+    input:
+      cmd: "ps --no-headers --pid <% ctx().pid %>"
+      cwd: <% ctx().output_dir %>
+      hosts: <% ctx().plumber_host %>
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          msg="Plumber crashed running {{ ctx().pipeline }}
+          in {{ ctx().output_dir }}."
+        do:
+          report_failure
+
+  report_failure:
+    action: core.inject_trigger
+    input:
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: "Failed to analyse sample <% ctx().sample_id %>"
+        message: <% ctx().msg %>
+    next:
+      - do: fail

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -299,6 +299,15 @@ tasks:
           in {{ ctx().output_dir }}."
         do:
           report_failure
+      - when: "{{ succeeded() and ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
+        do: wait
+      - when: "{{ succeeded() and ctx().pipeline != 'genomic-medicine-sweden/Twist_Solid' }}"
+        do: noop
+
+  wait:
+    action: core.local
+    input:
+      cmd: sleep 20m
 
   report_failure:
     action: core.inject_trigger

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -305,9 +305,9 @@ tasks:
         do: noop
 
   wait:
-    action: core.local
+    action: core.pause
     input:
-      cmd: sleep 20m
+      max_pause: 1800
 
   report_failure:
     action: core.inject_trigger

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -21,7 +21,7 @@ vars:
   - pipeline_version:
   - pipeline_profile:
   - plumber_config_version:
-  - plumber_cmd:
+  - plumber_extra_arguments:
   - case_id:
   - fastq_files:
   - analysis_ids:
@@ -99,6 +99,7 @@ tasks:
           - pipeline_version: <% result().result.Version %>
           - pipeline_profile: <% result().result.Profile %>
           - plumber_config_version: <% result().result.ConfigVersion %>
+          - plumber_extra_arguments: "{{ result().result.get('ExtraArguments', '') }}"
         do:
           divide_workflow
       - when: "{{ failed() }}"
@@ -268,7 +269,7 @@ tasks:
     input:
       cmd: "nohup plumber run <% ctx().pipeline %>
         --version <% ctx().pipeline_version %> --config-version <% ctx().plumber_config_version %>
-        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> &> plumber.log & echo $!"
+        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> <% ctx().plumber_extra_arguments %> &> plumber.log & echo $!"
       cwd: <% ctx().output_dir %>
       hosts: <% ctx().plumber_host %>
       env: <% ctx().plumber_env %>

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -104,7 +104,7 @@ tasks:
           divide_workflow
       - when: "{{ failed() }}"
         publish:
-          msg="Failed to get TestProfile configuration.
+          msg="Failed to get TestProfile configuration from config-repo.
           {{ result() | to_json_string }}"
         do:
           report_failure
@@ -145,7 +145,7 @@ tasks:
           noop
       - when: "{{ failed() }}"
         publish:
-          msg="Failed to get number of reads for sample from Cleve.
+          msg="Failed to get flowcell name from Cleve.
           {{ result() | to_json_string }}"
         do:
           report_failure
@@ -160,7 +160,7 @@ tasks:
           rd_make_case_id
       - when: "{{ failed() }}"
         publish:
-          msg="Failed to output directory.
+          msg="Failed to create output directory {{ ctx().output_dir }}.
           {{ result() | to_json_string }}"
         do: report_failure
 
@@ -198,7 +198,7 @@ tasks:
         do: format_cleve_input_files
       - when: "{{ failed() }}"
         publish:
-          msg="Failed to make rare-disease samplesheet.
+          msg="Failed to make raredisease samplesheet.
           {{ result() | to_json_string }}"
         do: report_failure
 
@@ -217,7 +217,7 @@ tasks:
           format_cleve_input_files
       - when: "{{ failed() }}"
         publish:
-          msg="Failed to output directory.
+          msg="Failed to prepare for running {{ ctx().pipeline }}.
           {{ result() | to_json_string }}"
         do: report_failure
 
@@ -305,7 +305,7 @@ tasks:
     input:
       trigger_name: gmc_norr_analysis.email_notification
       payload:
-        subject: "Failed to analyse sample <% ctx().sample_id %>"
+        subject: "Failed to start pipeline for sample <% ctx().sample_id %> from <% ctx().run_id %>"
         message: <% ctx().msg %>
     next:
       - do: fail

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -21,7 +21,7 @@ vars:
   - pipeline_version:
   - pipeline_profile:
   - plumber_config_version:
-  - plumber_extra_arguments:
+  - plumber_additional_arguments:
   - case_id:
   - fastq_files:
   - analysis_ids:
@@ -99,7 +99,7 @@ tasks:
           - pipeline_version: <% result().result.Version %>
           - pipeline_profile: <% result().result.Profile %>
           - plumber_config_version: <% result().result.ConfigVersion %>
-          - plumber_extra_arguments: "{{ result().result.get('ExtraArguments', '') }}"
+          - plumber_additional_arguments: "{{ result().result.get('AdditionalArguments', '') }}"
         do:
           divide_workflow
       - when: "{{ failed() }}"
@@ -269,7 +269,7 @@ tasks:
     input:
       cmd: "nohup plumber run <% ctx().pipeline %>
         --version <% ctx().pipeline_version %> --config-version <% ctx().plumber_config_version %>
-        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> <% ctx().plumber_extra_arguments %> &> plumber.log & echo $!"
+        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> <% ctx().plumber_additional_arguments %> &> plumber.log & echo $!"
       cwd: <% ctx().output_dir %>
       hosts: <% ctx().plumber_host %>
       env: <% ctx().plumber_env %>

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -11,12 +11,10 @@ input:
   - host
 
 vars:
-  - msg:
   - work_dir:
 
 output:
   - work_dir: <% ctx().work_dir %>
-  - error: <% ctx().msg %>
 
 tasks:
   name_work_dir:
@@ -37,9 +35,6 @@ tasks:
         do:
           symlink_fastq
       - when: "{{ failed() }}"
-        publish:
-          - msg: "Failed to make work dir {{ ctx().work_dir }}/fastq
-             {{ result() | to_json_string }}"
 
   symlink_fastq:
     with: fastq_file in <% ctx().fastq_files %>
@@ -50,10 +45,6 @@ tasks:
       - when: "{{ succeeded() }}"
         do:
           make_gms_solid_input_files
-      - when: "{{ failed() }}"
-        publish:
-          - msg: "Failed to symlink fastq files.
-             {{ result() | to_json_string }}"
 
   make_gms_solid_input_files:
     action: core.remote
@@ -62,7 +53,3 @@ tasks:
       cwd: "{{ ctx().work_dir }}"
       hosts: <% ctx().host %>
     next:
-      - when: "{{ failed() }}"
-        publish:
-          - msg: "Failed to make GMS Solid input files
-             {{ result() | to_json_string }}"

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -1,0 +1,85 @@
+version: 1.0
+name: prepare_twist_solid
+description: >
+  Workflow for preparing to start a Twist Solid analysis of a sample with plumber
+
+input:
+  - sample_id
+  - run_id
+  - fastq_files
+  - twist_solid_dir
+
+vars:
+  - msg:
+  - work_dir:
+
+output:
+  - workdir: <% ctx().work_dir %>
+
+tasks:
+  name_work_dir:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - work_dir: "{{ ctx().twist_solid_dir }}/{{ ctx().run_id }}/{{ ctx().sample_id }}"
+        do:
+          make_work_dir
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "{{ result() }}"
+        do:
+          - report_failure
+
+  make_work_dir:
+    action: core.local
+    input:
+      cmd: "mkdir -p {{ ctx().work_dir }}/fastq"
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          symlink_fastq
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "{{ result() }}"
+        do:
+          - report_failure
+
+  symlink_fastq:
+    with: fastq_file in "{{ ctx().fastq_files }}"
+    action: core.local
+    input:
+      cmd: 'ln -s "<% item(fastq_file) %>" "{{ ctx().workdir }}/fastq"'
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          make_gms_solid_input_files
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "{{ result() }}"
+        do:
+          - report_failure
+
+  make_gms_solid_input_files:
+    action: core.local
+    input:
+      cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform NovaSeqXPlus'
+      cwd: "{{ ctx().work_dir }}"
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "{{ result() }}"
+        do:
+          - report_failure
+
+  report_failure:
+    action: core.inject_trigger
+    input:
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: >
+          Failed prepare sample {{ ctx().sample_id }} for plumber analysis of GMS Solid
+        message: <% ctx().msg %>
+    next:
+      - when: "{{ succeeded() }}"
+        do: fail

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -8,6 +8,7 @@ input:
   - run_id
   - fastq_files
   - twist_solid_dir
+  - host
 
 vars:
   - msg:
@@ -58,10 +59,11 @@ tasks:
           - report_failure
 
   make_gms_solid_input_files:
-    action: core.local
+    action: core.remote
     input:
       cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform NovaSeqXPlus'
       cwd: "{{ ctx().work_dir }}"
+      hosts: <% ctx().host %>
     next:
       - when: "{{ failed() }}"
         publish:

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -52,4 +52,3 @@ tasks:
       cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform NovaSeqXPlus'
       cwd: "{{ ctx().work_dir }}"
       hosts: <% ctx().host %>
-    next:

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -68,6 +68,6 @@ tasks:
   make_gms_solid_input_files:
     action: core.remote
     input:
-      cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform {{ ctx().platform }}'
+      cmd: '/adhome/svcgenetikstackstorm/.local/bin/hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform {{ ctx().platform }}'
       cwd: "{{ ctx().work_dir }}"
       hosts: <% ctx().host %>

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -16,6 +16,7 @@ vars:
 
 output:
   - work_dir: <% ctx().work_dir %>
+  - error: <% ctx().msg %>
 
 tasks:
   name_work_dir:
@@ -38,9 +39,7 @@ tasks:
       - when: "{{ failed() }}"
         publish:
           - msg: "Failed to make work dir {{ ctx().work_dir }}/fastq
-             {{ result() }}"
-        do:
-          - report_failure
+             {{ result() | to_json_string }}"
 
   symlink_fastq:
     with: fastq_file in <% ctx().fastq_files %>
@@ -54,9 +53,7 @@ tasks:
       - when: "{{ failed() }}"
         publish:
           - msg: "Failed to symlink fastq files.
-             {{ result() }}"
-        do:
-          - report_failure
+             {{ result() | to_json_string }}"
 
   make_gms_solid_input_files:
     action: core.remote
@@ -68,18 +65,4 @@ tasks:
       - when: "{{ failed() }}"
         publish:
           - msg: "Failed to make GMS Solid input files
-             {{ result() }}"
-        do:
-          - report_failure
-
-  report_failure:
-    action: core.inject_trigger
-    input:
-      trigger_name: gmc_norr_analysis.email_notification
-      payload:
-        subject: >
-          Failed prepare sample {{ ctx().sample_id }} for plumber analysis of GMS Solid
-        message: <% ctx().msg %>
-    next:
-      - when: "{{ succeeded() }}"
-        do: fail
+             {{ result() | to_json_string }}"

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -12,6 +12,7 @@ input:
 
 vars:
   - work_dir:
+  - platform:
 
 output:
   - work_dir: <% ctx().work_dir %>
@@ -44,11 +45,29 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         do:
-          make_gms_solid_input_files
+          get_run_platform
+
+  get_run_platform:
+    action: cleve.get_runs
+    input:
+      run_id: <% ctx(run_id) %>
+    retry:
+      when: "{{ failed() }}"
+      delay: 1
+      count: 2
+    next:
+      - when: <% succeeded() and result().result.body.metadata.count = 0 %>
+        do: fail
+      - when: <% succeeded() and result().result.body.metadata.count > 1 %>
+        do: fail
+      - when: <% succeeded() and result().result.body.metadata.count = 1 %>
+        publish:
+          - platform: <% result().result.body.runs.first().platform.replace(" ", "") %>
+        do: make_gms_solid_input_files
 
   make_gms_solid_input_files:
     action: core.remote
     input:
-      cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform NovaSeqXPlus'
+      cmd: 'hydra-genetics create-input-files --nreads 5000 --directory fastq --tc 1.0 --platform {{ ctx().platform }}'
       cwd: "{{ ctx().work_dir }}"
       hosts: <% ctx().host %>

--- a/actions/workflows/prepare_twist_solid.yaml
+++ b/actions/workflows/prepare_twist_solid.yaml
@@ -14,7 +14,7 @@ vars:
   - work_dir:
 
 output:
-  - workdir: <% ctx().work_dir %>
+  - work_dir: <% ctx().work_dir %>
 
 tasks:
   name_work_dir:
@@ -25,11 +25,6 @@ tasks:
           - work_dir: "{{ ctx().twist_solid_dir }}/{{ ctx().run_id }}/{{ ctx().sample_id }}"
         do:
           make_work_dir
-      - when: "{{ failed() }}"
-        publish:
-          - msg: "{{ result() }}"
-        do:
-          - report_failure
 
   make_work_dir:
     action: core.local
@@ -41,22 +36,24 @@ tasks:
           symlink_fastq
       - when: "{{ failed() }}"
         publish:
-          - msg: "{{ result() }}"
+          - msg: "Failed to make work dir {{ ctx().work_dir }}/fastq
+             {{ result() }}"
         do:
           - report_failure
 
   symlink_fastq:
-    with: fastq_file in "{{ ctx().fastq_files }}"
+    with: fastq_file in <% ctx().fastq_files %>
     action: core.local
     input:
-      cmd: 'ln -s "<% item(fastq_file) %>" "{{ ctx().workdir }}/fastq"'
+      cmd: 'ln -s <% item(fastq_file) %> <% ctx().work_dir %>/fastq'
     next:
       - when: "{{ succeeded() }}"
         do:
           make_gms_solid_input_files
       - when: "{{ failed() }}"
         publish:
-          - msg: "{{ result() }}"
+          - msg: "Failed to symlink fastq files.
+             {{ result() }}"
         do:
           - report_failure
 
@@ -68,7 +65,8 @@ tasks:
     next:
       - when: "{{ failed() }}"
         publish:
-          - msg: "{{ result() }}"
+          - msg: "Failed to make GMS Solid input files
+             {{ result() }}"
         do:
           - report_failure
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -65,7 +65,9 @@ plumber:
     config_repo:
       type: string
       description: Link to the raw config-files repo, which has the files that translate TestProfile into a pipeline with arguments
-
     host:
       type: string
-      description: Where to run the analysis with plumber
+      description: The host where the analysis should be run with plumber
+    twist_solid_dir:
+      type: string
+      description: Path to prepare and run Twist Solid analyses from


### PR DESCRIPTION
Turns out there's probably not much reason to have specific actions for GMS Solid prep steps, as long as a core.local can take care of it! Athough the hydra-genetics command means that someone will have to install it first.... Maybe the hydra-genetics command should be done remotely? To collect all the dependencies in one user?

I put the twist_solid_dir parameter into the config (under plumber, with host and config repo), but I'm open to there being a better solution.

