### PR TITLE
feat: add suport for genomic-medicine-sweden/Twist_Solid in `get pipeline input files`

### DIFF
--- a/actions/get_pipeline_input_files.py
+++ b/actions/get_pipeline_input_files.py
@@ -1,7 +1,7 @@
 from st2common.runners.base_action import Action
 
 
-def get_rd_input_files(sample_id, analysis_id, fastq_files):
+def get_fastq_input_files(sample_id, analysis_id, fastq_files):
     input_files = []
     for file in fastq_files["R1"] + fastq_files["R2"]:
         input_files.append({'analysis_id': analysis_id, 'name':  file.split('/')[-1],
@@ -11,9 +11,9 @@ def get_rd_input_files(sample_id, analysis_id, fastq_files):
 
 class GetPipelineInputFilesAction(Action):
     def run(self, pipeline, fastq_files, analysis_ids, sample_id):
-        if pipeline == "nf-core/raredisease":
-            input_files = get_rd_input_files(sample_id, analysis_ids[sample_id],
-                                             fastq_files[sample_id])
+        if pipeline == "nf-core/raredisease" or pipeline == "genomic-medicine-sweden/Twist_Solid":
+            input_files = get_fastq_input_files(sample_id, analysis_ids[sample_id],
+                                                fastq_files[sample_id])
         else:
             return (False, f"Pipeline not supported: {pipeline}")
         return (True, input_files)


### PR DESCRIPTION
So far we only use the fastq files, so this is basically no difference. 

Closes #65