### PR TITLE
fix: rd workflow checks flowcell instead of number of reads per sample

### DIFF
--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -31,7 +31,7 @@ vars:
   - pid:
 
 output:
-  - workflow_msg: "{{ ctx().msg }}"
+  - stop_msg:
 
 tasks:
   get_sample_data:
@@ -54,7 +54,7 @@ tasks:
           get_fastq_files
       - when: "{{ succeeded() and result().result.body.TestProfile not in ctx().supported_profiles }}"
         publish:
-          msg="{{ result().result.body.TestProfile }} not supported in automation."
+          stop_msg="{{ result().result.body.TestProfile }} not supported in automation."
         do: noop
       - when: "{{ failed() }}"
         publish:
@@ -132,7 +132,7 @@ tasks:
           rd_prepare_output_folder
       - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         publish:
-          msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
+          stop_msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
         do:
           noop
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -31,7 +31,7 @@ vars:
   - pid:
 
 output:
-  - stop_msg:
+  - msg:
 
 tasks:
   get_sample_data:
@@ -54,7 +54,7 @@ tasks:
           get_fastq_files
       - when: "{{ succeeded() and result().result.body.TestProfile not in ctx().supported_profiles }}"
         publish:
-          stop_msg="{{ result().result.body.TestProfile }} not supported in automation."
+          msg="{{ result().result.body.TestProfile }} not supported in automation."
         do: noop
       - when: "{{ failed() }}"
         publish:
@@ -132,7 +132,7 @@ tasks:
           rd_prepare_output_folder
       - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         publish:
-          stop_msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
+          msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
         do:
           noop
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -130,7 +130,7 @@ tasks:
       - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         do:
           rd_prepare_output_folder
-      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
+      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name = '1.5B' %>
         publish:
           msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
         do:

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -132,7 +132,7 @@ tasks:
           rd_prepare_output_folder
       - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         publish:
-          workflow_msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
+          msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
         do:
           noop
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -111,7 +111,7 @@ tasks:
     next:
       - when: "{{ ctx().pipeline == 'nf-core/raredisease' }}"
         do:
-          rd_check_sample_reads
+          rd_check_flowcell
       - when: "{{ ctx().pipeline != 'nf-core/raredisease'}}"
         publish:
           msg="Unsupported pipeline {{ ctx().pipeline }}"
@@ -119,7 +119,7 @@ tasks:
           report_failure
 
   rd_check_flowcell: # stop the workflow if it's a prerun of the sequencing
-    action: cleve.get_run
+    action: cleve.get_runs
     input:
       run_id: <% ctx().run_id %>
     retry:

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -127,10 +127,10 @@ tasks:
       delay: 1
       count: 2
     next:
-      - when: <% succeeded() and result().result.body.runs.values().first().run_info.flowcell_name != '1.5B' %>
+      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         do:
           rd_prepare_output_folder
-      - when: <% succeeded() and result().result.body.runs.values().first().run_info.flowcell_name != '1.5B' %>
+      - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         publish:
           msg="Only {{ result().result.body.read_count }} reads.
           Probably a prerun sequencing, so stopping workflow here."

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -132,8 +132,7 @@ tasks:
           rd_prepare_output_folder
       - when: <% succeeded() and result().result.body.runs.first().run_info.flowcell_name != '1.5B' %>
         publish:
-          msg="Only {{ result().result.body.read_count }} reads.
-          Probably a prerun sequencing, so stopping workflow here."
+          workflow_msg="Sequenced on a 1.5B flowcell, so probably a prerun sequencing. Stopping workflow here."
         do:
           noop
       - when: "{{ failed() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -118,20 +118,19 @@ tasks:
         do:
           report_failure
 
-  rd_check_sample_reads: # stop the workflow if it's a prerun of the sequencing
-    action: cleve.get_run_qc
+  rd_check_flowcell: # stop the workflow if it's a prerun of the sequencing
+    action: cleve.get_run
     input:
       run_id: <% ctx().run_id %>
-      sample_id: <% ctx().sample_id %>
     retry:
       when: "{{ failed() }}"
       delay: 1
       count: 2
     next:
-      - when: "{{ succeeded() and result().result.body.read_count | int >= 4*10**8 }}"
+      - when: <% succeeded() and result().result.body.runs.values().first().run_info.flowcell_name != '1.5B' %>
         do:
           rd_prepare_output_folder
-      - when: "{{ succeeded() and result().result.body.read_count | int < 4*10**8 }}"
+      - when: <% succeeded() and result().result.body.runs.values().first().run_info.flowcell_name != '1.5B' %>
         publish:
           msg="Only {{ result().result.body.read_count }} reads.
           Probably a prerun sequencing, so stopping workflow here."

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -31,7 +31,7 @@ vars:
   - pid:
 
 output:
-  - msg:
+  - msg: <% ctx().msg %>
 
 tasks:
   get_sample_data:


### PR DESCRIPTION
The QC data is not always available (specifically for 10B flowcells?), so the old check does not work reliably.