### PR TITLE
fix(plumber_analysis): only email about failing to get sample info from iGene if the sample id starts with "Seq"

### DIFF
--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -56,12 +56,12 @@ tasks:
         publish:
           msg="{{ result().result.body.TestProfile }} not supported in automation."
         do: noop
-      - when: "{{ failed() and ctx().sample_id[0:4] != 'Seq' }}"
+      - when: "{{ failed() and not ctx().sample_id.startswith('Seq') }}"
         publish:
           msg="Failed to get sample data from the iGene API for {{ ctx().sample_id }}.
           {{ result() | to_json_string }}"
         do: noop
-      - when: "{{ failed() and ctx().sample_id[0:4] == 'Seq' }}"
+      - when: "{{ failed() and ctx().sample_id.startswith('Seq') }}"
         publish:
           msg="Failed to get sample data from the iGene API.
           {{ result() | to_json_string }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -56,7 +56,12 @@ tasks:
         publish:
           msg="{{ result().result.body.TestProfile }} not supported in automation."
         do: noop
-      - when: "{{ failed() }}"
+      - when: "{{ failed() and ctx().sample_id[0:4] != 'Seq' }}"
+        publish:
+          msg="Failed to get sample data from the iGene API for {{ ctx().sample_id }}.
+          {{ result() | to_json_string }}"
+        do: noop
+      - when: "{{ failed() and ctx().sample_id[0:4] == 'Seq' }}"
         publish:
           msg="Failed to get sample data from the iGene API.
           {{ result() | to_json_string }}"


### PR DESCRIPTION
Would have liked to check status code, but if the connection is completely down, the response won't have the right format.