### PR TITLE
fix(update_complete_plumber_analysis): increase rsync timeout and change flags to `-a --remove-source-files`

### DIFF
--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -124,7 +124,7 @@ tasks:
     action: core.local
     input:
       cmd: "rsync -aP <% ctx().workdir %> <% ctx().destination %>"
-      timeout: 5000
+      timeout: 7500
     next:
       - when: "{{ succeeded() }}"
         do: divide_pipeline_tasks

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -123,8 +123,8 @@ tasks:
   rsync_output:
     action: core.local
     input:
-      cmd: "rsync -a <% ctx().workdir %> <% ctx().destination %>"
-      timeout: 7500
+      cmd: "rsync -a --remove-source-files <% ctx().workdir %> <% ctx().destination %>"
+      timeout: 10000
     next:
       - when: "{{ succeeded() }}"
         do: divide_pipeline_tasks

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -123,7 +123,7 @@ tasks:
   rsync_output:
     action: core.local
     input:
-      cmd: "rsync -aP <% ctx().workdir %> <% ctx().destination %>"
+      cmd: "rsync -a <% ctx().workdir %> <% ctx().destination %>"
       timeout: 7500
     next:
       - when: "{{ succeeded() }}"


### PR DESCRIPTION
Is this enough, or should I increase more when we're at it? Also removed the -P flag, since no one is looking at tit, and the size of the message caused report_failure to fail (ironically).

Do we dare put back `--remove-source-files`?