### PR TITLE
fix(get_plumber_aruments): handle several downstream analyses

### DIFF
--- a/actions/get_plumber_arguments.py
+++ b/actions/get_plumber_arguments.py
@@ -3,13 +3,10 @@ import yaml
 import requests
 from st2common.runners.base_action import Action
 
-supported_applications = ["NfCoreRareDisease"]
-
 
 def get_supported_analysis(test_analyses):
     for analysis in test_analyses:
-        if analysis["ApplicationProfileName"] in supported_applications:
-            return analysis["ApplicationProfileName"], analysis["ApplicationProfileVersion"]
+        return analysis["ApplicationProfileName"], analysis["ApplicationProfileVersion"]
     return None, None
 
 

--- a/actions/get_plumber_arguments.py
+++ b/actions/get_plumber_arguments.py
@@ -4,14 +4,15 @@ import requests
 from st2common.runners.base_action import Action
 
 
-def get_supported_analysis(test_analyses):
-    for analysis in test_analyses:
-        return analysis["ApplicationProfileName"], analysis["ApplicationProfileVersion"]
-    return None, None
+def get_supported_analysis(test_analyses, number):
+    if number > len(test_analyses):
+        return None, None
+    analysis = test_analyses[number - 1]
+    return analysis["ApplicationProfileName"], analysis["ApplicationProfileVersion"]
 
 
 class GetPlumberArgumentsAction(Action):
-    def run(self, config_path, test_profile):
+    def run(self, config_path, test_profile, number):
         test_profile_path = os.path.join(config_path, "test-profile-config/test_profiles/",
                                          f"{test_profile}.yaml")
         r = requests.get(test_profile_path)
@@ -25,10 +26,10 @@ class GetPlumberArgumentsAction(Action):
         if test_analyses is None:
             return (False, "Error: DownstreamAnalysis not found")
         else:
-            app_profile, app_profile_v = get_supported_analysis(test_analyses)
+            app_profile, app_profile_v = get_supported_analysis(test_analyses, number)
 
         if app_profile is None:
-            return (False, "Error: Unsupported DownstreamAnalysis")
+            return (False, "Error: Test doesn't have that many downstream analyses")
 
         app_profile_path = os.path.join(config_path, "test-profile-config/application_profiles/",
                                         f"{app_profile}.yaml")

--- a/actions/get_plumber_arguments.yaml
+++ b/actions/get_plumber_arguments.yaml
@@ -11,10 +11,15 @@ parameters:
     description: URL to the (raw) config file repo
     type: string
     required: true
-    default: "{{ config_context.plumber.config_repo}}"
+    default: "{{ config_context.plumber.config_repo }}"
     position: 0
   test_profile:
     description: The iGene TestProfile to get the corresponding settings for
     type: string
     required: true
     position: 1
+  number:
+    description: Which of the downstream analysis to choose
+    default: 1
+    position: 2
+    type: integer


### PR DESCRIPTION
For cases such as GMS Solid and scout-annotation. Will default to the first one, so will still work for raredisease with no changes.