### PR TITLE
feat: add `second plumber analysis` workflow

### DIFF
--- a/actions/second_plumber_analysis.yaml
+++ b/actions/second_plumber_analysis.yaml
@@ -1,0 +1,25 @@
+---
+name: plumber_analysis
+pack: gmc_norr_analysis
+description: Workflow to run downstream analysis of a sample with plumber
+runner_type: orquesta
+entry_point: workflows/plumber_analysis.yaml
+enabled: true
+
+parameters:
+  first_pipeline:
+    description: The previous analysis run (e.g. GMS Solid)
+    type: string
+    required: true
+  first_analysis_id:
+    description: The ID of the first analysis in Cleve
+    type: string
+    required: true
+  first_workdir:
+    description: The path to the first analysis
+    type: string
+    required: true
+  plumber_host:
+    description: Host to run plumber on
+    type: string
+    default: "{{config_context.plumber.host}}"

--- a/actions/second_plumber_analysis.yaml
+++ b/actions/second_plumber_analysis.yaml
@@ -1,9 +1,9 @@
 ---
-name: plumber_analysis
+name: second_plumber_analysis
 pack: gmc_norr_analysis
-description: Workflow to run downstream analysis of a sample with plumber
+description: Workflow to run second downstream analysis of a sample with plumber
 runner_type: orquesta
-entry_point: workflows/plumber_analysis.yaml
+entry_point: workflows/second_plumber_analysis.yaml
 enabled: true
 
 parameters:

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -155,7 +155,7 @@ tasks:
         do: add_secondary_analysis_to_cleve
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
@@ -177,7 +177,7 @@ tasks:
         do: start_plumber
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -136,8 +136,8 @@ tasks:
           - input_files:
             - <% result().result.where($.type.matches("bam")).select($) %>
             - <% result().result.where($.type.matches("vcf")).select($) %>
-          - bam_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("bam")).select($.path) %>
-          - vcf_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path) %>
+          - bam_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("bam")).select($.path).first() %>
+          - vcf_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path).first() %>
         do: make_secondary_pipeline_input
       - when: <% failed() %>
         publish:

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -1,0 +1,223 @@
+
+version: 1.0
+
+description: Build Scout load config for a case, and load into scout and loqusdb.
+
+input:
+  - first_pipeline
+  - first_analysis_id
+  - first_workdir
+  - plumber_host
+
+tasks:
+  get_sample_id:
+    action: core.local
+    input:
+      cmd: basename <% ctx().first_workdir %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - sample_id: <% result().stdout %>
+        do: get_run_id
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  get_run_id:
+    action: cleve.get_analyses
+    input:
+      analysis_id: <% ctx().first_analysis_id %>
+    retry:
+      when: "{{ failed() }}"
+      delay: 1
+      count: 2
+    next:
+      - when: <% failed() %>
+        publish:
+          - msg: Cleve not reachable
+        do: report_failure
+      - when: <% succeeded() and result().result.body.metadata.count = 0 %>
+        publish:
+          - msg: analysis <% ctx().analysis_id %> not found in Cleve
+        do: report_failure
+      - when: <% succeeded() and result().result.body.metadata.count > 1 %>
+        publish:
+          - msg: more than one analysis with ID <% ctx().analysis_id %> found in Cleve
+        do: report_failure
+      - when: <% succeeded() and result().result.body.metadata.count = 1 %>
+        publish:
+          - run_id: <% result().result.body.analyses.first().runs.first() %>
+        do:
+          make_case_id
+
+  make_case_id:
+    action: gmc_norr_analysis.make_case_id
+    input:
+      samples:
+        - <% ctx().sample_id %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - case_id: <% result().result %>
+        do:
+          get_test_profile
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to generate case id.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  get_test_profile:
+    action: igene.get_sample
+    input:
+      sample_id: <% ctx().sample_id %>
+    retry:
+      when: "{{ failed() }}"
+      delay: 1
+      count: 2
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - test_profile: <% result().result.body.TestProfile %>
+        do:
+          get_plumber_arguments
+      - when: "{{ failed()  }}"
+        publish:
+          msg="Failed to get sample data from the iGene API.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+
+  get_plumber_arguments:
+    action: gmc_norr_analysis.get_plumber_arguments
+    input:
+       test_profile: <% ctx().test_profile %>
+       number: 2
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - pipeline: <% result().result.Pipeline %>
+          - pipeline_version: <% result().result.Version %>
+          - pipeline_profile: <% result().result.Profile %>
+          - plumber_config_version: <% result().result.ConfigVersion %>
+          - new_workdir: "{{ ctx().first_workdir }}/{{ ctx().pipeline.split('/')[-1] }}"
+        do: make_new_work_dir
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  make_new_dir:
+    action: core.local
+    input:
+      cmd:  "mkdir -p <% ctx().new_workdir %>"
+    next:
+      - when: <% succeeded() %>
+        do: get_input_files
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  get_input_files:
+    action: gmc_norr_analysis.get_pipeline_output_files
+    input:
+      pipeline: <% ctx().first_pipeline %>
+      sample_id: <% ctx().sample_id %>
+      case_id: <% ctx().case_id %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - input_files:
+            - <% result().result.where($.type.matches("bam")).select($) %>
+            - <% result().result.where($.type.matches("vcf")).select($) %>
+          - bam_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("bam")).select($.path) %>
+          - vcf_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path) %>
+        do: make_secondary_pipeline_input
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  make_secondary_pipeline_input:
+    action: core.local
+    input:
+      cmd: 'echo -e "sample\tfamily\tvcf\tbam\n{{ ctx().sample_id }}\t{{ ctx().case_id }}\t{{ ctx().vcf_file }}\t{{ ctx().bam_file }}" > samples.tsv'
+      cwd: <% ctx().new_workdir %>
+    next:
+      - when: <% succeeded() %>
+        do: add_secondary_analysis_to_cleve
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  add_secondary_analysis_to_cleve:
+    action: cleve.add_analysis
+    input:
+      input_files: "{% for file in ctx().input_files %}
+        {% set file = dict(file.items(), analysis_id = ctx().first_analysis_id, name = file.path) %}
+        {{ file }}{% endfor %}"
+      path: <% ctx().new_workdir %>
+      software: <% ctx().pipeline %>
+      software_version: <% ctx().pipeline_version %>
+      run_id: <% ctx().run_id %>
+      state: pending
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - plumber_analysis_id: <% result().result.body.analysis_id %>
+        do: start_plumber
+      - when: <% failed() %>
+        publish:
+          - msg: <% result() %>
+        do:
+          - report_failure
+
+  start_plumber:
+    action: core.remote
+    input:
+      cmd: "nohup plumber run <% ctx().pipeline %>
+        --version <% ctx().pipeline_version %> --config-version <% ctx().plumber_config_version %>
+        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> &> plumber.log"
+      cwd: <% ctx().new_workdir %>
+      hosts: <% ctx().plumber_host %>
+      timeout: 2500
+    next:
+      - when: <% succeeded() %>
+        do:
+          - start_update_complete_workflow
+      - when: <% failed() %>
+        publish:
+          - msg: <% result().values().first().stderr %>
+        do:
+          - report_failure
+
+  start_update_complete_workflow:
+    action: gmc_norr_analysis.update_complete_plumber_analysis
+    input:
+      analysis_id: <% ctx().prev_analysis_id %>
+      pipeline: <% ctx().prev_pipeline %>
+      workdir: <% ctx().prev_analysis_path %>
+      sample_id: <% ctx().sample_id %>
+      run_id: <% ctx().run_id %>
+      case_id: <% ctx().case_id %>
+      secondary_analysis_id: <% ctx().plumber_analysis_id %>
+      secondary_pipeline: <% ctx().pipeline %>
+
+  report_failure:
+    action: core.inject_trigger
+    input:
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: "Failed to bridge to scout in {{ ctx().prev_analysis_dir }}"
+        message: <% ctx().msg %>
+    next:
+      - do: fail

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -117,14 +117,14 @@ tasks:
       cmd:  "mkdir -p <% ctx().new_workdir %>"
     next:
       - when: <% succeeded() %>
-        do: get_input_files
+        do: get_first_output_files
       - when: <% failed() %>
         publish:
           - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
-  get_input_files:
+  get_first_output_files:
     action: gmc_norr_analysis.get_pipeline_output_files
     input:
       pipeline: <% ctx().first_pipeline %>
@@ -133,15 +133,32 @@ tasks:
     next:
       - when: <% succeeded() %>
         publish:
-          - input_files:
-            - <% result().result.where($.type.matches("bam")).select($).first() %>
-            - <% result().result.where($.type.matches("vcf")).select($).first() %>
-          - bam_file: <% ctx().first_workdir %>/<% result().result.where($.type.matches("bam")).select($.path).first() %>
-          - vcf_file: <% ctx().first_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path).first() %>
-        do: make_secondary_pipeline_input
+          - first_output_files: <% result().result %>
+        do: parse_first_output_files
       - when: <% failed() %>
         publish:
           - msg: <% result() %>
+        do:
+          - report_failure
+
+  parse_first_output_files:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - input_files: "[{% for file in ctx().first_output_files %}
+              {% if file.type == 'bam' or file.type == 'vcf_snv' %}
+              {% set file = dict(file.items(), analysis_id = ctx().first_analysis_id,
+              name = file.path.split('/')[-1]) %}
+              {{ file }},
+              {% endif %}
+              {% endfor %}]"
+          - bam_file: <% ctx().first_workdir %>/<% ctx().first_output_files.where($.type.matches("bam")).select($.path).first() %>
+          - vcf_file: <% ctx().first_workdir %>/<% ctx().first_output_files.where($.type.matches("vcf")).select($.path).first() %>
+        do: make_secondary_pipeline_input
+      - when: <% failed() %>
+        publish:
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
@@ -162,10 +179,7 @@ tasks:
   add_secondary_analysis_to_cleve:
     action: cleve.add_analysis
     input:
-      input_files: "[{% for file in ctx().input_files %}
-        {% set file = dict(file.items(), analysis_id = ctx().first_analysis_id, name = file.path) %}
-        {{ file }},
-        {% endfor %}]"
+      input_files: <% ctx().input_files %>
       path: <% ctx().new_workdir %>
       software: <% ctx().pipeline %>
       software_version: <% ctx().pipeline_version %>

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -120,7 +120,7 @@ tasks:
         do: get_input_files
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -40,11 +40,11 @@ tasks:
         do: report_failure
       - when: <% succeeded() and result().result.body.metadata.count = 0 %>
         publish:
-          - msg: analysis <% ctx().analysis_id %> not found in Cleve
+          - msg: analysis <% ctx().first_analysis_id %> not found in Cleve
         do: report_failure
       - when: <% succeeded() and result().result.body.metadata.count > 1 %>
         publish:
-          - msg: more than one analysis with ID <% ctx().analysis_id %> found in Cleve
+          - msg: more than one analysis with ID <% ctx().first_analysis_id %> found in Cleve
         do: report_failure
       - when: <% succeeded() and result().result.body.metadata.count = 1 %>
         publish:
@@ -111,7 +111,7 @@ tasks:
         do:
           - report_failure
 
-  make_new_dir:
+  make_new_work_dir:
     action: core.local
     input:
       cmd:  "mkdir -p <% ctx().new_workdir %>"
@@ -203,9 +203,9 @@ tasks:
   start_update_complete_workflow:
     action: gmc_norr_analysis.update_complete_plumber_analysis
     input:
-      analysis_id: <% ctx().prev_analysis_id %>
-      pipeline: <% ctx().prev_pipeline %>
-      workdir: <% ctx().prev_analysis_path %>
+      analysis_id: <% ctx().first_analysis_id %>
+      pipeline: <% ctx().first_pipeline %>
+      workdir: <% ctx().first_workdir %>
       sample_id: <% ctx().sample_id %>
       run_id: <% ctx().run_id %>
       case_id: <% ctx().case_id %>
@@ -217,7 +217,7 @@ tasks:
     input:
       trigger_name: gmc_norr_analysis.email_notification
       payload:
-        subject: "Failed to bridge to scout in {{ ctx().prev_analysis_dir }}"
+        subject: "Failed to bridge to scout in {{ ctx().first_workdir }}"
         message: <% ctx().msg %>
     next:
       - do: fail

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -134,10 +134,10 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - input_files:
-            - <% result().result.where($.type.matches("bam")).select($) %>
-            - <% result().result.where($.type.matches("vcf")).select($) %>
-          - bam_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("bam")).select($.path).first() %>
-          - vcf_file: <% ctx().new_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path).first() %>
+            - <% result().result.where($.type.matches("bam")).select($).first() %>
+            - <% result().result.where($.type.matches("vcf")).select($).first() %>
+          - bam_file: <% ctx().first_workdir %>/<% result().result.where($.type.matches("bam")).select($.path).first() %>
+          - vcf_file: <% ctx().first_workdir %>/<% result().result.where($.type.matches("vcf")).select($.path).first() %>
         do: make_secondary_pipeline_input
       - when: <% failed() %>
         publish:
@@ -162,9 +162,10 @@ tasks:
   add_secondary_analysis_to_cleve:
     action: cleve.add_analysis
     input:
-      input_files: "{% for file in ctx().input_files %}
+      input_files: "[{% for file in ctx().input_files %}
         {% set file = dict(file.items(), analysis_id = ctx().first_analysis_id, name = file.path) %}
-        {{ file }}{% endfor %}"
+        {{ file }},
+        {% endfor %}]"
       path: <% ctx().new_workdir %>
       software: <% ctx().pipeline %>
       software_version: <% ctx().pipeline_version %>

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -8,6 +8,7 @@ input:
   - first_analysis_id
   - first_workdir
   - plumber_host
+  - plumber_additional_arguments
 
 tasks:
   get_sample_id:
@@ -103,6 +104,7 @@ tasks:
           - pipeline_version: <% result().result.Version %>
           - pipeline_profile: <% result().result.Profile %>
           - plumber_config_version: <% result().result.ConfigVersion %>
+          - plumber_additional_arguments: "{{ result().result.get('AdditionalArguments', '') }}"
           - new_workdir: "{{ ctx().first_workdir }}/{{ ctx().pipeline.split('/')[-1] }}"
         do: make_new_work_dir
       - when: <% failed() %>
@@ -205,7 +207,7 @@ tasks:
     input:
       cmd: "nohup plumber run <% ctx().pipeline %>
         --version <% ctx().pipeline_version %> --config-version <% ctx().plumber_config_version %>
-        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> &> plumber.log"
+        -p <% ctx().pipeline_profile %> --analysis-id <% ctx().plumber_analysis_id %> <% ctx().plumber_additional_arguments %> &> plumber.log"
       cwd: <% ctx().new_workdir %>
       hosts: <% ctx().plumber_host %>
       timeout: 2500

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -21,7 +21,7 @@ tasks:
         do: get_run_id
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
@@ -36,7 +36,7 @@ tasks:
     next:
       - when: <% failed() %>
         publish:
-          - msg: Cleve not reachable
+          - msg: "Cleve not reachable. {{ result() | to_json_string }}"
         do: report_failure
       - when: <% succeeded() and result().result.body.metadata.count = 0 %>
         publish:
@@ -107,7 +107,7 @@ tasks:
         do: make_new_work_dir
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
@@ -137,7 +137,7 @@ tasks:
         do: parse_first_output_files
       - when: <% failed() %>
         publish:
-          - msg: <% result() %>
+          - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -144,7 +144,7 @@ tasks:
   parse_first_output_files:
     action: core.noop
     next:
-      - when: <% succeeded() %>
+      - when: <% succeeded() and ctx().pipeline = 'gmc-norr/scout-annotation' %>
         publish:
           - input_files: "[{% for file in ctx().first_output_files %}
               {% if file.type == 'bam' or file.type == 'vcf_snv' %}
@@ -154,15 +154,19 @@ tasks:
               {% endif %}
               {% endfor %}]"
           - bam_file: <% ctx().first_workdir %>/<% ctx().first_output_files.where($.type.matches("bam")).select($.path).first() %>
-          - vcf_file: <% ctx().first_workdir %>/<% ctx().first_output_files.where($.type.matches("vcf")).select($.path).first() %>
-        do: make_secondary_pipeline_input
+          - vcf_file: <% ctx().first_workdir %>/<% ctx().first_output_files.where($.type.matches("vcf_snv")).select($.path).first() %>
+        do: make_scout_annotation_input
+      - when: <% succeeded() and ctx().pipeline != 'gmc-norr/scout-annotation' %>
+        publish:
+          - msg: "Unsupported pipeline {{ ctx().pipeline }}"
+        do: noop
       - when: <% failed() %>
         publish:
           - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
 
-  make_secondary_pipeline_input:
+  make_scout_annotation_input:
     action: core.local
     input:
       cmd: 'echo -e "sample\tfamily\tvcf\tbam\n{{ ctx().sample_id }}\t{{ ctx().case_id }}\t{{ ctx().vcf_file }}\t{{ ctx().bam_file }}" > samples.tsv'

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -122,12 +122,24 @@ tasks:
           - plumber_config_version: <% result().result.ConfigVersion %>
           - plumber_additional_arguments: "{{ result().result.get('AdditionalArguments', '') }}"
           - new_workdir: "{{ ctx().first_workdir }}/{{ ctx().pipeline.split('/')[-1] }}"
-        do: make_new_work_dir
+        do: divide_workflow
       - when: <% failed() %>
         publish:
           - msg: "{{ result() | to_json_string }}"
         do:
           - report_failure
+
+  divide_workflow:
+    action: core.noop
+    next:
+      - when: "{{ ctx().pipeline == 'gmc-norr/scout-annotation' }}"
+        do:
+          make_new_work_dir
+      - when: "{{ ctx().pipeline != 'gmc-norr/scout-annotation'}}"
+        publish:
+          - msg: "Unsupported pipeline {{ ctx().pipeline }}"
+        do:
+          - noop
 
   make_new_work_dir:
     action: core.local

--- a/actions/workflows/second_plumber_analysis.yaml
+++ b/actions/workflows/second_plumber_analysis.yaml
@@ -1,14 +1,30 @@
 
 version: 1.0
 
-description: Build Scout load config for a case, and load into scout and loqusdb.
+description: Run a secondary pipeline, for example gmc-norr/scout-annotation,
+  for pipelines that need a second step before loading the case into Scout.
 
 input:
   - first_pipeline
   - first_analysis_id
   - first_workdir
   - plumber_host
-  - plumber_additional_arguments
+
+vars:
+  - msg:
+  - run_id:
+  - case_id:
+  - sample_id:
+  - pipeline:
+  - pipeline_version:
+  - pipeline_profile:
+  - plumber_config_version:
+  - plumber_additional_arguments:
+  - new_workdir:
+  - input_files:
+  - bam_file:
+  - vcf_file:
+  - plumber_analysis_id:
 
 tasks:
   get_sample_id:
@@ -217,7 +233,7 @@ tasks:
           - start_update_complete_workflow
       - when: <% failed() %>
         publish:
-          - msg: <% result().values().first().stderr %>
+          - msg: "Failed to run {{ ctx().pipeline }} for {{ ctx().sample }} with plumber"
         do:
           - report_failure
 
@@ -238,7 +254,7 @@ tasks:
     input:
       trigger_name: gmc_norr_analysis.email_notification
       payload:
-        subject: "Failed to bridge to scout in {{ ctx().first_workdir }}"
+        subject: "Failed run secondary pipeline in {{ ctx().first_workdir }}"
         message: <% ctx().msg %>
     next:
       - do: fail

--- a/policies/second_plumber_analysis.yaml
+++ b/policies/second_plumber_analysis.yaml
@@ -1,0 +1,9 @@
+---
+name: second_plumber_analysis.concurrency
+description: Limits the concurrent executions for the second plumber analysis workflow.
+enabled: true
+resource_ref: gmc_norr_analysis.second_plumber_analysis
+policy_type: action.concurrency
+parameters:
+  action: delay
+  threshold: 1


### PR DESCRIPTION
Currently only for running scout-annotation after GMS Solid (and if we're lucky, only that)