### PR TITLE
fix(update_complete_plumber_analysis): make msg variable only stderr

### DIFF
--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -21,6 +21,9 @@ vars:
   - destination:
   - new_workdir:
 
+output:
+  - msg: <% ctx().msg %>
+
 tasks:
   check_start:
     action: core.noop
@@ -42,7 +45,7 @@ tasks:
           get_run_id
       - when: "{{ failed() }}"
         publish:
-          - msg: "{{ result() }}"
+          - msg: <% result().stderr %>
         do:
           - report_failure
 
@@ -128,7 +131,7 @@ tasks:
         do: rsync_output
       - when: "{{ failed() }}"
         publish:
-          - msg: <% result() %>
+          - msg: <% result().stderr %>
         do:
           - report_failure
 
@@ -142,7 +145,7 @@ tasks:
         do: divide_pipeline_tasks
       - when: "{{ failed() }}"
         publish:
-          - msg: <% result() %>
+          - msg: <% result().stderr %>
         do:
           - report_failure
 


### PR DESCRIPTION
Because the full object isn't automatically parsed as a string, so the report_failure action fails