### PR TITLE
feat: log samples analysed with plumber

### DIFF
--- a/actions/check_worksheet_samples.yaml
+++ b/actions/check_worksheet_samples.yaml
@@ -1,0 +1,24 @@
+---
+name: check_worksheet_samples
+pack: gmc_norr_analysis
+description: Workflow to check if all samples of the worksheet with
+  the TestProfile have been analysed
+runner_type: orquesta
+entry_point: workflows/check_worksheet_samples.yaml
+enabled: true
+
+parameters:
+  test_profile:
+    description: The test profile that the samples were analysed with
+    type: string
+    required: true
+  completed_samples:
+    description: The samples that completed the analysis successfully
+    type: array
+    items:
+      type: string
+  failed_samples:
+    description: The samples that failed the analysis
+    type: array
+    items:
+      type: string

--- a/actions/log_plumber_failure.yaml
+++ b/actions/log_plumber_failure.yaml
@@ -1,0 +1,20 @@
+---
+name: log_plumber_failure
+pack: gmc_norr_analysis
+description: >
+  Workflow for starting downstream analysis of samples with plumber
+  from a ready sequencing run
+runner_type: orquesta
+entry_point: workflows/log_plumber_failure.yaml
+enabled: true
+
+parameters:
+  workdir:
+    description: Workdir of failed analysis
+    type: string
+    required: true
+  log_suffix:
+    description: Workdir of failed analysis
+    type: string
+    required: true
+    default: "{{ config_context.plumber.log_suffix }}"

--- a/actions/plumber_analysis.yaml
+++ b/actions/plumber_analysis.yaml
@@ -42,3 +42,8 @@ parameters:
     immutable: true
     default:
       - WGSRareDisease_1
+  log_suffix:
+    description: Workdir of failed analysis
+    type: string
+    required: true
+    default: "{{ config_context.plumber.log_suffix }}"

--- a/actions/update_complete_plumber_analysis.yaml
+++ b/actions/update_complete_plumber_analysis.yaml
@@ -40,3 +40,8 @@ parameters:
     description: The pipeline the secondary analysis was performed with. Required for Twist Solid analyses.
     type: string
     required: false
+  log_suffix:
+    description: Workdir of failed analysis
+    type: string
+    required: true
+    default: "{{ config_context.plumber.log_suffix }}"

--- a/actions/workflows/check_worksheet_samples.yaml
+++ b/actions/workflows/check_worksheet_samples.yaml
@@ -1,0 +1,82 @@
+version: "1.0"
+
+description: Check finished finished samples against worksheet in iGene.
+
+input:
+  - test_profile
+  - completed_samples
+  - failed_samples
+
+vars:
+  - msg:
+  - run_ids:
+
+tasks:
+  get_sample_info:
+    action: igene.get_sample
+    input:
+      sample_id: "{{ ctx().completed_samples[0] }}"
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to get sample info from the iGene API.
+          {{ result() | to_json_string }}"
+      - when: "{{ succeded() and result().result.body.TestProfile != ctx().test_profile }}"
+        publish:
+          msg="Something is wrong.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+      - when: "{{ succeded() and result().result.body.TestProfile == ctx().test_profile }}"
+        publish:
+          - worksheet_id: <% result().result.body.WorksheetID %>
+        do:
+          get_worksheet_info
+
+  get_worksheet_info:
+    action: igene.get_worksheets
+    input:
+      worksheet_id: "{{ ctx().worksheet_id }}"
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to get sample info from the iGene API.
+          {{ result() | to_json_string }}"
+        do:
+          report_failure
+      - when: "{{ succeded() }}"
+        publish:
+            - worksheet_samples: <% result().result.body.where($.TestProfile.matches(ctx().test_profile)).select($.SampleID) %>
+        do:
+          check_samples
+
+  check_samples:
+    action: core.noop
+    next:
+      - when: "{{ ctx().worksheet_samples | sort != (ctx().completed_samples + ctx().failed_samples) | sort }}"
+        publish:
+          - msg: "Samples on worksheet: {{ ctx().worksheet_samples }}
+              Completed samples: {{ ctx().completed_samples }}
+              Failed samples: {{ ctx().failed_samples }}"
+        do:
+          report_failure
+      - when: "{{ ctx().worksheet_samples | sort != (ctx().completed_samples + ctx().failed_samples) | sort }}"
+        do:
+          report_success
+
+  report_failure:
+    action: core.inject_trigger
+    input:
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: "Failed: {{ ctx).test_profile }} analyses on {{ ctx().worksheet_id }} missing"
+        message: "{{ ctx().msg }}"
+
+  report_success:
+    action: core.inject_trigger
+    input: # should maybe go to another email?
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: "{{ ctx().worksheet_id }} {{ ctx).test_profile }} analyses done"
+        message: "Successful samples: {{ ctx().samples | to_json_string }}
+          Failed samples: {{ ctx().failed_samples | to_json_string }}"

--- a/actions/workflows/log_plumber_failure.yaml
+++ b/actions/workflows/log_plumber_failure.yaml
@@ -1,0 +1,72 @@
+version: "1.0"
+
+description: >
+  Update the log of a failed analysis to say that the sample failed.
+
+input:
+  - workdir
+  - log_suffix
+
+vars:
+  - msg:
+  - sample_id:
+  - logfile:
+
+tasks:
+  get_sample_id:
+    action: core.local
+    input:
+      cmd: basename <% ctx().workdir %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - sample_id: <% result().stdout %>
+        do:
+          find_log_file
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "Failed to parse sample ID from path
+              {{ result().stderr }}"
+        do:
+          - report_failure
+
+  find_log_file:
+    action: core.local
+    input:
+      cmd: grep -l <% ctx().sample_id %> ../../*<% ctx().log_suffix %>
+      cwd: <% ctx().workdir %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - sample_id: <% result().stdout %>
+        do:
+          log_failure
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "Failed to find logfile.
+              {{ result().stderr }}"
+        do:
+          - report_failure
+
+  log_failure:
+    action: core.local
+    input:
+      cmd: 'sed -i "s/{{ ctx().sample_id}} started/{{ ctx().sample_id}} failed/" {{ ctx().logfile }}'
+      cwd: <% ctx().workdir %>
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "Failed to update log file
+              {{ result().stderr }}"
+        do:
+          - report_failure
+
+  report_failure:
+    action: core.inject_trigger
+    input:
+      trigger_name: gmc_norr_analysis.email_notification
+      payload:
+        subject: "Failed to log failure {{ctx().workdir}}"
+        message: "{{ ctx().msg }}"
+    next:
+      - do: fail

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -232,11 +232,28 @@ tasks:
         publish:
           - plumber_analysis_id: <% result().result.body.analysis_id %>
         do:
-          start_plumber
+          log_sample
       - when: "{{ failed() }}"
         publish:
           msg="Failed to add {{ ctx().pipeline }} analysis to Cleve
             {{ result().stderr }}"
+        do:
+          - report_failure
+
+  log_sample:
+    action: core.local
+    input:
+      cmd:  echo <% ctx().sample_id %> started >> <% ctx().test_profile %>.automation.log
+      cwd: <% ctx().run_path %>
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          input_files="{{ result().result }}"
+        do:
+          start_plumber
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to log"
         do:
           - report_failure
 

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -243,7 +243,7 @@ tasks:
   log_sample:
     action: core.local
     input:
-      cmd:  echo <% ctx().sample_id %> started >> <% ctx().test_profile %>.<% ctx().log_suffix %>
+      cmd:  echo <% ctx().sample_id %> started >> <% ctx().test_profile %><% ctx().log_suffix %>
       cwd: <% ctx().run_path %>
     next:
       - when: "{{ succeeded() }}"

--- a/actions/workflows/plumber_analysis.yaml
+++ b/actions/workflows/plumber_analysis.yaml
@@ -243,7 +243,7 @@ tasks:
   log_sample:
     action: core.local
     input:
-      cmd:  echo <% ctx().sample_id %> started >> <% ctx().test_profile %>.automation.log
+      cmd:  echo <% ctx().sample_id %> started >> <% ctx().test_profile %>.<% ctx().log_suffix %>
       cwd: <% ctx().run_path %>
     next:
       - when: "{{ succeeded() }}"

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -16,6 +16,8 @@ input:
 
 vars:
   - msg:
+  - platform:
+  - run_path:
   - output_files:
   - secondary_output_files:
   - destination:
@@ -100,6 +102,7 @@ tasks:
       - when: <% succeeded() and result().result.body.metadata.count = 1 %>
         publish:
           - platform: <% result().result.body.runs.first().platform %>
+          - run_path: <% result().result.body.runs.first().path %>
         do: get_destination
 
   get_destination:
@@ -310,7 +313,21 @@ tasks:
       output_path: <% ctx().new_workdir %>
       secondary_analysis_id: <% ctx().secondary_analysis_id %>
     next:
-      - when: "{{ succeeded() and ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
+      - when: "{{ succeeded() }}"
+        do: log_sample
+
+  log_sample:
+    action: core.local
+    input:
+      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> complete/' <% ctx().pipeline %>.automation.log
+      cwd: <% ctx().run_path %>
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          msg="Failed to log success"
+        do:
+          - report_failure
+      - when: "{{ succeeded() }} and ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
         do: copy_bam
 
   copy_bam:

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -13,6 +13,7 @@ input:
   - case_id
   - secondary_analysis_id
   - secondary_pipeline
+  - log_suffix
 
 vars:
   - msg:
@@ -22,6 +23,7 @@ vars:
   - secondary_output_files:
   - destination:
   - new_workdir:
+  - test_profile:
 
 output:
   - msg: <% ctx().msg %>
@@ -314,12 +316,14 @@ tasks:
       secondary_analysis_id: <% ctx().secondary_analysis_id %>
     next:
       - when: "{{ succeeded() }}"
+        publish:
+          - test_profile: <% result().output.test_profile %>
         do: log_sample
 
   log_sample:
     action: core.local
     input:
-      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> completed/' <% ctx().pipeline %>.automation.log
+      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> completed/' <% ctx().test_profile %>.<% ctx().log_suffix %>
       cwd: <% ctx().run_path %>
     next:
       - when: "{{ failed() }}"

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -323,7 +323,7 @@ tasks:
   log_sample:
     action: core.local
     input:
-      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> completed/' <% ctx().test_profile %>.<% ctx().log_suffix %>
+      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> completed/' <% ctx().test_profile %><% ctx().log_suffix %>
       cwd: <% ctx().run_path %>
     next:
       - when: "{{ failed() }}"

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -319,7 +319,7 @@ tasks:
   log_sample:
     action: core.local
     input:
-      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> complete/' <% ctx().pipeline %>.automation.log
+      cmd:  sed -i 's/<% ctx().sample_id %> started/<% ctx().sample_id %> completed/' <% ctx().pipeline %>.automation.log
       cwd: <% ctx().run_path %>
     next:
       - when: "{{ failed() }}"

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -309,6 +309,23 @@ tasks:
       analysis_id: <% ctx().analysis_id %>
       output_path: <% ctx().new_workdir %>
       secondary_analysis_id: <% ctx().secondary_analysis_id %>
+    next:
+      - when: "{{ succeeded() and ctx().pipeline == 'genomic-medicine-sweden/Twist_Solid' }}"
+        do: copy_bam
+
+  copy_bam:
+    action: gmc_norr_seqdata.copy_bam
+    input:
+      run_id: <% ctx().run_id %>
+      pipeline: <% ctx().pipeline %>
+      bam_path: <% ctx().new_workdir %>/bam_dna
+    next:
+      - when: "{{ failed() }}"
+        publish:
+          - msg: "Failed to move bam files to K:
+              {{ result() | to_json_string }}"
+        do:
+          - report_failure
 
   report_failure:
     action: core.inject_trigger

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -72,3 +72,4 @@ plumber:
     log_suffix:
       type: string
       description: Suffix to use when naming automation log files
+      default: .stackstorm.log

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -69,3 +69,6 @@ plumber:
     host:
       type: string
       description: Where to run the analysis with plumber
+    log_suffix:
+      type: string
+      description: Suffix to use when naming automation log files

--- a/rules/check_worksheet_samples.yaml
+++ b/rules/check_worksheet_samples.yaml
@@ -1,0 +1,16 @@
+---
+name: check_worksheet_samples
+pack: gmc_norr_analysis
+description: >
+  Send a notification email
+enabled: true
+
+trigger:
+  type: cleve.complete_worksheet
+
+action:
+  ref: gmc_norr_analysis.check_worksheet_samples
+  parameters:
+    test_profile: "{{ trigger.test_profile }}"
+    completed_samples: "{{ trigger.completed_samples }}"
+    failed_samples: "{{ trigger.failed_samples }}"

--- a/rules/log_plumber_failure.yaml
+++ b/rules/log_plumber_failure.yaml
@@ -1,0 +1,24 @@
+---
+name: log_plumber_failure
+pack: gmc_norr_analysis
+description: >
+  Log when a run ends in failure
+enabled: true
+
+trigger:
+  type: "core.st2.webhook"
+  parameters:
+    url: "plumber"
+
+criteria:
+  trigger.body.message_type:
+    type: equals
+    pattern: end
+  trigger.body.success:
+    type: equals
+    pattern: false
+
+action:
+  ref: gmc_norr_analysis.log_plumber_failure
+  parameters:
+    workdir: "{{ trigger.body.workdir }}"


### PR DESCRIPTION
Not sure if this is the right approach...

Need the testprofile from the scout workflow, unless we use the pipeline name instead. Will need to set the log suffix to the same thing in the sensor

Maybe sending the email should move into the log failure action?