### PR TITLE
feat: handle half-complete GMS solid runs by skipping output files if state is not "suceeded" in .plumber-analysis.json

### DIFF
--- a/actions/get_pipeline_output_files.py
+++ b/actions/get_pipeline_output_files.py
@@ -31,7 +31,7 @@ def get_rd_output_files(sample_id, case_id):
     return output_files
 
 
-def get_twist_solid_output_files(sample_id, case_id):
+def get_twist_solid_output_files(sample_id: str, case_id: str, complete: bool = True):
     output_files = [
         {'path': f'bam_dna/{sample_id}_T.bam',
          'level': 'sample', 'type': 'bam', 'parent_id': sample_id
@@ -39,9 +39,6 @@ def get_twist_solid_output_files(sample_id, case_id):
         {'path': f'results/dna/{sample_id}_T/vcf/{sample_id}_T.annotated.'
          'exon_only.filter.hard_filter.codon_snv.vcf',
          'level': 'case', 'type': 'vcf_snv', 'parent_id': case_id
-         },
-        {'path': f"results/dna/{sample_id}_T/{sample_id}_T.general_report.html",
-         'level': 'case', 'type': 'html', 'parent_id': case_id
          },
         {'path': f"results/dna/{sample_id}_T/cnv/{sample_id}_T"
          ".pathology_purecn.cnv.html",
@@ -58,7 +55,12 @@ def get_twist_solid_output_files(sample_id, case_id):
          "filtered.score.tsv",
          'level': 'case', 'type': 'text', 'parent_id': case_id
          }]
-
+    if complete:
+        output_files.append(
+            {'path': f"results/dna/{sample_id}_T/{sample_id}_T.general_report.html",
+             'level': 'case', 'type': 'html', 'parent_id': case_id
+             }
+             )
     return output_files
 
 
@@ -75,11 +77,11 @@ def get_scout_annotation_output_files(sample_id, case_id):
 
 
 class GetPipelineOutputFiles(Action):
-    def run(self, pipeline, sample_id, case_id):
+    def run(self, pipeline, sample_id, case_id, complete):
         if pipeline == "nf-core/raredisease":
             output_files = get_rd_output_files(sample_id, case_id)
         elif pipeline == "genomic-medicine-sweden/Twist_Solid":
-            output_files = get_twist_solid_output_files(sample_id, case_id)
+            output_files = get_twist_solid_output_files(sample_id, case_id, complete)
         elif pipeline == "gmc-norr/scout-annotation":
             output_files = get_scout_annotation_output_files(sample_id, case_id)
         else:

--- a/actions/get_pipeline_output_files.py
+++ b/actions/get_pipeline_output_files.py
@@ -31,7 +31,7 @@ def get_rd_output_files(sample_id, case_id):
     return output_files
 
 
-def get_twist_solid_output_files(sample_id: str, case_id: str, complete: bool = True):
+def get_twist_solid_output_files(sample_id: str, case_id: str, complete: bool):
     output_files = [
         {'path': f'bam_dna/{sample_id}_T.bam',
          'level': 'sample', 'type': 'bam', 'parent_id': sample_id

--- a/actions/get_pipeline_output_files.yaml
+++ b/actions/get_pipeline_output_files.yaml
@@ -19,3 +19,6 @@ parameters:
     description: The case ID
     type: string
     required: false
+  complete:
+    type: boolean
+    default: true

--- a/actions/get_pipeline_output_files.yaml
+++ b/actions/get_pipeline_output_files.yaml
@@ -8,7 +8,7 @@ enabled: true
 
 parameters:
   pipeline:
-    description: The pipeline name (in plumber formatting)
+    description: The pipeline name, e.g. nf-core/raredisease
     type: string
     required: true
   sample_id:
@@ -20,5 +20,7 @@ parameters:
     type: string
     required: false
   complete:
+    description: Whether the analysis was complete, or if only a subset of the output
+      files should be returned. Only relevant for genomic-medicine-sweden/Twist_Solid
     type: boolean
     default: true

--- a/actions/workflows/update_complete_plumber_analysis.yaml
+++ b/actions/workflows/update_complete_plumber_analysis.yaml
@@ -16,6 +16,7 @@ input:
 
 vars:
   - msg:
+  - complete:
   - output_files:
   - secondary_output_files:
   - destination:
@@ -191,10 +192,14 @@ tasks:
           - report_failure
 
   check_twist_solid_needed_variables:
-    action: core.noop
+    action: core.local
+    input:
+      cmd: 'cat {{ ctx().new_workdir }}/.plumber-analysis.json'
     next:
       - when: <% ctx().case_id != null and ctx().secondary_pipeline != null
          and ctx().secondary_analysis_id != null %>
+        publish:
+          - complete: "{{ result().stdout.state.name == 'succeeded'}}"
         do: format_secondary_output_files
       - when: <% ctx().case_id = null or ctx().secondary_pipeline = null
          or ctx().secondary_analysis_id = null %>
@@ -259,6 +264,7 @@ tasks:
       pipeline: "{{ ctx().pipeline }}"
       case_id: "{{ ctx().case_id }}"
       sample_id: "{{ ctx().sample_id }}"
+      complete: "{{ ctx().complete }}"
     next:
       - when: "{{ succeeded() }}"
         publish:


### PR DESCRIPTION
So that we can push through samples that only half failed.